### PR TITLE
Makes Linux installation more version-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Download the latest release for your operating system from the
 ### Linux
 
 - `mkdir -p $HOME/.config/obs-studio/plugins`
-- Untar, e.g.: `tar -zxvf obs-livesplit-one-v0.0.1-x86_64-unknown-linux-gnu.tar.gz -C
-   $HOME/.config/obs-studio/plugins/`
+- Untar, e.g.: `tar -zxvf obs-livesplit-one-*-x86_64-unknown-linux-gnu.tar.gz -C $HOME/.config/obs-studio/plugins/`
 
 ### macOS
 


### PR DESCRIPTION
The previous installation command for Linux worked only for v0.0.2. This modification makes the command working for all previous and future versions of OBS Livesplit One.