### PR TITLE
Add option to auto-save splits on reset

### DIFF
--- a/obs/src/lib.rs
+++ b/obs/src/lib.rs
@@ -88,6 +88,20 @@ pub extern "C" fn blog(_log_level: c_int, _format: *const c_char) {
 }
 
 #[no_mangle]
+pub extern "C" fn obs_properties_add_bool(
+    _props: *mut obs_properties_t,
+    _name: *const c_char,
+    _description: *const c_char,
+) -> *mut obs_property_t {
+    panic!()
+}
+
+#[no_mangle]
+pub extern "C" fn obs_data_get_bool(_data: *mut obs_data_t, _name: *const c_char) -> bool {
+    panic!()
+}
+
+#[no_mangle]
 pub extern "C" fn obs_properties_add_int(
     _props: *mut obs_properties_t,
     _name: *const c_char,
@@ -157,6 +171,15 @@ pub extern "C" fn gs_technique_end_pass(_technique: *mut gs_technique_t) {
 
 #[no_mangle]
 pub extern "C" fn obs_get_base_effect(_effect: obs_base_effect) -> *mut gs_effect_t {
+    panic!()
+}
+
+#[no_mangle]
+pub extern "C" fn obs_data_set_default_bool(
+    _data: *mut obs_data_t,
+    _name: *const c_char,
+    _val: bool,
+) {
     panic!()
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -52,6 +52,12 @@ extern "C" {
     ) -> *mut obs_property_t;
     pub fn obs_data_get_string(data: *mut obs_data_t, name: *const c_char) -> *const c_char;
     pub fn blog(log_level: c_int, format: *const c_char, ...);
+    pub fn obs_properties_add_bool(
+        props: *mut obs_properties_t,
+        name: *const c_char,
+        description: *const c_char,
+    ) -> *mut obs_property_t;
+    pub fn obs_data_get_bool(data: *mut obs_data_t, name: *const c_char) -> bool;
     pub fn obs_properties_add_int(
         props: *mut obs_properties_t,
         name: *const c_char,
@@ -77,6 +83,7 @@ extern "C" {
     pub fn gs_technique_end(technique: *mut gs_technique_t);
     pub fn gs_technique_end_pass(technique: *mut gs_technique_t);
     pub fn obs_get_base_effect(effect: obs_base_effect) -> *mut gs_effect_t;
+    pub fn obs_data_set_default_bool(data: *mut obs_data_t, name: *const c_char, val: bool);
     pub fn obs_data_set_default_int(data: *mut obs_data_t, name: *const c_char, val: c_longlong);
     pub fn obs_properties_add_button(
         props: *mut obs_properties_t,


### PR DESCRIPTION
Just a little convenience feature, since I've had multiple runs after which I've closed OBS without remembering to save the splits file, having to either live with losing the splits or watching back the relevant runs and redoing the splits.

First time working with anything OBS-related, so I hope this is fine.