### PR TITLE
Fix game processes being in a zombie state when exiting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,30 +620,32 @@ unsafe extern "C" fn start_game_clicked(
 
         let mut process = Command::new(state.game_path.clone());
 
-        let child = process.spawn();
-        
+        let _child = process.spawn();
+
         #[cfg(unix)]
         {
             // For Unix systems only, spawn a new thread that waits for the process to exit.
             // This avoids keeping the process in a zombie state and never letting go of it until
             // the plugin is unloaded
-            
-            let mut child = match child {
-                Ok(child) => { child }
+
+            let mut child = match _child {
+                Ok(child) => child,
                 Err(e) => {
                     warn!("Failure starting the game process {e}");
                     return false;
                 }
             };
-            
-            std::thread::spawn(move || {                
-                match child.wait() {
-                    Ok(exit_status) => { info!("Game process exited with {}", exit_status); }
-                    Err(e) => { warn!("Failure waiting for the game process' exit: {e}"); }
+
+            std::thread::spawn(move || match child.wait() {
+                Ok(exit_status) => {
+                    info!("Game process exited with {}", exit_status);
+                }
+                Err(e) => {
+                    warn!("Failure waiting for the game process' exit: {e}");
                 }
             });
         }
-        
+
         return false;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 #[cfg(all(unix, feature = "auto-splitting"))]
+#[cfg(unix)]
 use std::thread;
 
 #[cfg(feature = "auto-splitting")]


### PR DESCRIPTION
This fixes the game processes going into a zombie state when they exit on Unix systems.
We weren't properly waiting for their exit so this goes and fixes that.
The thread spawning approach may not be the best, but it works for this and we can think of an other solution if needed at some point.