### PR TITLE
GitHub Actions: Release the MacOS builds in the new .plugin format

### DIFF
--- a/.github/workflows/before_deploy.sh
+++ b/.github/workflows/before_deploy.sh
@@ -15,7 +15,9 @@ main() {
         mkdir -p $stage/obs-livesplit-one/bin/$PLUGIN_BITS
         cp target/$TARGET/max-opt/libobs_livesplit_one.so $stage/obs-livesplit-one/bin/$PLUGIN_BITS/libobs-livesplit-one.so
     elif [ "$OS_NAME" = "macOS-latest" ]; then
-        cp target/$TARGET/max-opt/libobs_livesplit_one.dylib $stage/obs-livesplit-one.so
+        mkdir -p $stage/obs-livesplit-one.plugin/Contents/MacOS
+        mkdir -p $stage/obs-livesplit-one.plugin/Contents/Resources
+        cp target/$TARGET/max-opt/libobs_livesplit_one.dylib $stage/obs-livesplit-one.plugin/Contents/MacOS/obs-livesplit-one.so
     elif [ "$OS_NAME" = "windows-latest" ]; then
         cp target/$TARGET/max-opt/obs_livesplit_one.dll $stage/obs-livesplit-one.dll
     fi

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Download the latest release for your operating system from the
 
 - Right click your `OBS` -> Options -> Show in Finder
 - Right click the `OBS.app` -> Show Package Contents
-- Drag `obs-livesplit-one.so` into `Contents/PlugIns`
+- Drag `obs-livesplit-one.plugin` into `Contents/PlugIns`
 
 ## Usage
 


### PR DESCRIPTION
This changes how the MacOS builds are being released by using the .plugin format that newer OBS versions require to load a plugin, this means that the user will just be able to copy the folder to the right place and it should just work and appear under OBS.

This pull request fixes issues #20 and #12