### PR TITLE
Implement UI to enable / disable custom auto splitter settings

### DIFF
--- a/obs/src/lib.rs
+++ b/obs/src/lib.rs
@@ -248,3 +248,33 @@ pub extern "C" fn obs_module_get_config_path(
 ) -> *const c_char {
     panic!()
 }
+#[no_mangle]
+pub extern "C" fn obs_properties_add_list(
+    _props: *mut obs_properties_t,
+    _name: *const c_char,
+    _description: *const c_char,
+    _combo_type: obs_combo_type,
+    _combo_format: obs_combo_format,
+) -> *mut obs_property_t {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_property_list_add_string(
+    _prop: *mut obs_property_t,
+    _name: *const c_char,
+    _val: *const c_char,
+) -> size_t {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_set_bool(_data: *mut obs_data_t, _name: *const c_char, _val: bool) {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_set_string(
+    _data: *mut obs_data_t,
+    _name: *const c_char,
+    _val: *const c_char,
+) {
+    panic!()
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -75,6 +75,20 @@ extern "C" {
         description: *const c_char,
         text_type: obs_text_type,
     ) -> *mut obs_property_t;
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_properties_add_list(
+        props: *mut obs_properties_t,
+        name: *const c_char,
+        description: *const c_char,
+        combo_type: obs_combo_type,
+        combo_format: obs_combo_format,
+    ) -> *mut obs_property_t;
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_property_list_add_string(
+        prop: *mut obs_property_t,
+        name: *const c_char,
+        val: *const c_char,
+    ) -> size_t;
     pub fn obs_properties_add_int(
         props: *mut obs_properties_t,
         name: *const c_char,
@@ -129,4 +143,8 @@ extern "C" {
         module: *mut obs_module_t,
         file: *const c_char,
     ) -> *const c_char;
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_data_set_bool(data: *mut obs_data_t, name: *const c_char, val: bool);
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_data_set_string(data: *mut obs_data_t, name: *const c_char, val: *const c_char);
 }

--- a/src/ffi_types.rs
+++ b/src/ffi_types.rs
@@ -45,6 +45,19 @@ pub const OBS_TEXT_PASSWORD: obs_text_type = 1;
 pub const OBS_TEXT_MULTILINE: obs_text_type = 2;
 pub const OBS_TEXT_INFO: obs_text_type = 3;
 
+pub type obs_combo_type = u32;
+pub const OBS_COMBO_TYPE_INVALID: obs_combo_type = 0;
+pub const OBS_COMBO_TYPE_EDITABLE: obs_combo_type = 1;
+pub const OBS_COMBO_TYPE_LIST: obs_combo_type = 2;
+pub const OBS_COMBO_TYPE_RADIO: obs_combo_type = 3;
+
+pub type obs_combo_format = u32;
+pub const OBS_COMBO_FORMAT_INVALID: obs_combo_format = 0;
+pub const OBS_COMBO_FORMAT_INT: obs_combo_format = 1;
+pub const OBS_COMBO_FORMAT_FLOAT: obs_combo_format = 2;
+pub const OBS_COMBO_FORMAT_STRING: obs_combo_format = 3;
+pub const OBS_COMBO_FORMAT_BOOL: obs_combo_format = 4;
+
 pub type obs_data_t = obs_data;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This PR adds UI elements to be able to set the auto splitter custom settings. The list of settings will get refreshed / reset every time the user opens the properties window (without resetting the actual settings of course, just for the UI), you can then select a setting to change and you will be able to see it's tooltip, current value and enable or disable it.
I think the most unfortunate thing here is the need to keep the OBS settings object around in the state but it is needed to reset the list back to it's original state and obs doesn't give access to it in get_properties. I think it mostly comes from the fact that this isn't the intended use of lists but I feel like it's the one that makes the most sense in this case.