### PR TITLE
Fix MacOS build on OBS 29+

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,22 +98,27 @@ jobs:
 
           - label: macOS aarch64
             target: aarch64-apple-darwin
+            rust_flags: -L framework=/Applications/OBS.app/Contents/Frameworks
             os: macOS-latest
+            arm: yes
             features: auto-splitting
             cross: skip
             install_target: true
 
           - label: macOS x86_64
             target: x86_64-apple-darwin
+            rust_flags: -L framework=/Applications/OBS.app/Contents/Frameworks
             os: macOS-latest
+            arm: no
             features: auto-splitting
             cross: skip
 
           - label: macOS x86_64-v3
             target: x86_64-apple-darwin
             target_rename: x86_64_v3-apple-darwin
-            rust_flags: -C target-cpu=x86-64-v3
+            rust_flags: -C target-cpu=x86-64-v3 -L framework=/Applications/OBS.app/Contents/Frameworks
             os: macOS-latest
+            arm: no
             features: auto-splitting
             cross: skip
 
@@ -129,6 +134,14 @@ jobs:
       - name: Install Target
         if: matrix.install_target != ''
         run: rustup target add ${{ matrix.target }}
+
+      - name: Install arm64 OBS
+        if: matrix.os == 'macOS-latest' && matrix.arm == 'yes'
+        run: curl https://cdn-fastly.obsproject.com/downloads/obs-studio-29.1.3-macos-arm64.dmg -o obs.dmg && hdiutil attach obs.dmg && sudo cp -R /Volumes/obs-studio-29.1.3-macos-arm64/OBS.app /Applications && hdiutil unmount /Volumes/obs-studio-29.1.3-macos-arm64
+
+      - name: Install x64 OBS
+        if: matrix.os == 'macOS-latest' && matrix.arm == 'no'
+        run: brew install --cask obs
 
       - name: Download cross
         if: matrix.cross == ''

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,7 +15,8 @@ use std::{
 
 pub use crate::ffi_types::*;
 
-#[link(name = "obs", kind = "dylib")]
+#[cfg_attr(target_os = "macos", link(name = "libobs", kind = "framework"))]
+#[cfg_attr(not(target_os = "macos"), link(name = "obs", kind = "dylib"))]
 extern "C" {
     pub fn obs_register_source_s(info: *const obs_source_info, size: size_t);
     pub fn gs_texture_create(


### PR DESCRIPTION
Since OBS 29 intentionally broke plugins on MacOS (by moving the access of libobs through the framework file), this PR goes and hopefully, fixes the MacOS build for everyone.

We are achieving this by linking specifically against libobs.framework in ffi.rs (only on MacOS).
Also, the MacOS GitHub Actions runners now need to be pointed at the right path for libobs. Finally, they now install OBS through a dmg image or the brew package manager depending on if we're building for arm or not.

That last part is a bit annoying because we cannot install the arm version of OBS through brew since the runners are on macOS x86_64, it could potentially break if OBS decides to remove that specific dmg image file but I think this is good for now.

Hopefully with these changes, #20 can be resolved!