### PR TITLE
Add advanced options to start a game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_derive",
+ "serde_json",
+ "shlex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ livesplit-core = { git = "https://github.com/LiveSplit/livesplit-core", features
     "font-loading",
 ] }
 log = { version = "0.4.6", features = ["serde"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
+serde_json = "1.0.105"
 
 # crates needed for the auto splitter management code to work as expected`
 anyhow = { version = "1.0.75", optional = true }
@@ -31,11 +34,12 @@ reqwest = { version = "0.11.18", features = [
     "blocking",
     "rustls-tls-native-roots",
 ], default-features = false, optional = true }
-serde = { version = "1.0.188", optional = true }
-serde_derive = { version = "1.0.188", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 obs = { path = "obs" }
+
+[target.'cfg(not(windows))'.dependencies]
+shlex = "1.1.0"
 
 [features]
 default = ["auto-splitting"]
@@ -46,8 +50,6 @@ auto-splitting = [
     "dep:percent-encoding",
     "dep:quick-xml",
     "dep:reqwest",
-    "dep:serde",
-    "dep:serde_derive",
 ]
 
 [profile.max-opt]
@@ -55,6 +57,7 @@ inherits = "release"
 lto = true
 panic = "abort"
 codegen-units = 1
+strip = true
 
 [profile.max-opt.build-override]
 opt-level = 0

--- a/obs/src/lib.rs
+++ b/obs/src/lib.rs
@@ -259,6 +259,17 @@ pub extern "C" fn obs_properties_add_list(
     panic!()
 }
 #[no_mangle]
+pub extern "C" fn obs_properties_add_editable_list(
+    _props: *mut obs_properties_t,
+    _name: *const c_char,
+    _description: *const c_char,
+    _list_type: obs_editable_list_type,
+    _filter: *const c_char,
+    _default_path: *const c_char,
+) -> *mut obs_property_t {
+    panic!()
+}
+#[no_mangle]
 pub extern "C" fn obs_property_list_add_string(
     _prop: *mut obs_property_t,
     _name: *const c_char,
@@ -276,5 +287,29 @@ pub extern "C" fn obs_data_set_string(
     _name: *const c_char,
     _val: *const c_char,
 ) {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_get_array(_data: *mut obs_data_t, _name: *const c_char) -> *mut c_void {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_array_count(_array: *mut c_void) -> size_t {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_array_item(_array: *mut c_void, _idx: size_t) -> *mut obs_data_t {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_array_release(_array: *mut c_void) {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_release(_data: *mut obs_data_t) {
+    panic!()
+}
+#[no_mangle]
+pub extern "C" fn obs_data_get_json(_data: *mut obs_data_t) -> *const c_char {
     panic!()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -68,7 +68,6 @@ extern "C" {
         description: *const c_char,
     ) -> *mut obs_property_t;
     pub fn obs_data_get_bool(data: *mut obs_data_t, name: *const c_char) -> bool;
-    #[cfg(feature = "auto-splitting")]
     pub fn obs_properties_add_text(
         props: *mut obs_properties_t,
         name: *const c_char,
@@ -82,6 +81,14 @@ extern "C" {
         description: *const c_char,
         combo_type: obs_combo_type,
         combo_format: obs_combo_format,
+    ) -> *mut obs_property_t;
+    pub fn obs_properties_add_editable_list(
+        props: *mut obs_properties_t,
+        name: *const c_char,
+        description: *const c_char,
+        list_type: obs_editable_list_type,
+        filter: *const c_char,
+        default_path: *const c_char,
     ) -> *mut obs_property_t;
     #[cfg(feature = "auto-splitting")]
     pub fn obs_property_list_add_string(
@@ -131,9 +138,7 @@ extern "C" {
     pub fn obs_property_set_description(prop: *mut obs_property_t, description: *const c_char);
     #[cfg(feature = "auto-splitting")]
     pub fn obs_property_set_enabled(prop: *mut obs_property_t, enabled: bool);
-    #[cfg(feature = "auto-splitting")]
     pub fn obs_property_set_visible(prop: *mut obs_property_t, visible: bool);
-    #[cfg(feature = "auto-splitting")]
     pub fn obs_properties_get(
         props: *mut obs_properties_t,
         prop: *const c_char,
@@ -147,4 +152,11 @@ extern "C" {
     pub fn obs_data_set_bool(data: *mut obs_data_t, name: *const c_char, val: bool);
     #[cfg(feature = "auto-splitting")]
     pub fn obs_data_set_string(data: *mut obs_data_t, name: *const c_char, val: *const c_char);
+
+    pub fn obs_data_get_array(data: *mut obs_data_t, name: *const c_char) -> *mut c_void;
+    pub fn obs_data_array_count(array: *mut c_void) -> size_t;
+    pub fn obs_data_array_item(array: *mut c_void, idx: size_t) -> *mut obs_data_t;
+    pub fn obs_data_array_release(array: *mut c_void);
+    pub fn obs_data_release(data: *mut obs_data_t);
+    pub fn obs_data_get_json(data: *mut obs_data_t) -> *const c_char;
 }

--- a/src/ffi_types.rs
+++ b/src/ffi_types.rs
@@ -58,6 +58,11 @@ pub const OBS_COMBO_FORMAT_FLOAT: obs_combo_format = 2;
 pub const OBS_COMBO_FORMAT_STRING: obs_combo_format = 3;
 pub const OBS_COMBO_FORMAT_BOOL: obs_combo_format = 4;
 
+pub type obs_editable_list_type = u32;
+pub const OBS_EDITABLE_LIST_TYPE_STRINGS: obs_editable_list_type = 0;
+pub const OBS_EDITABLE_LIST_TYPE_FILES: obs_editable_list_type = 1;
+pub const OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS: obs_editable_list_type = 2;
+
 pub type obs_data_t = obs_data;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -104,6 +109,7 @@ pub struct obs_mouse_event {
 
 pub type obs_path_type = u32;
 pub const OBS_PATH_FILE: obs_path_type = 0;
+pub const OBS_PATH_DIRECTORY: obs_path_type = 2;
 
 pub type obs_properties_t = obs_properties;
 #[repr(C)]


### PR DESCRIPTION
This patch adds the ability to provide command line arguments, a working directory and environment variables to the game you want to start (it also has a toggle to hide these settings if you don't need them). This can be very helpful in case you need to start a game in a specific way. For some reason, the 32 bits version of the Windows build doesn't seem to work with the winsafe crate being used to parse the game arguments, we'll have to see what we can do about that.