### PR TITLE
Add FileSelect Widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#dd0a22967a4755c5a52d12a5499dfefd86dd404d"
+source = "git+https://github.com/LiveSplit/livesplit-core#cbbee142db79a48fcb35b901739bc675e7574f12"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#dd0a22967a4755c5a52d12a5499dfefd86dd404d"
+source = "git+https://github.com/LiveSplit/livesplit-core#cbbee142db79a48fcb35b901739bc675e7574f12"
 dependencies = [
  "base64-simd",
  "bytemuck",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.7.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#dd0a22967a4755c5a52d12a5499dfefd86dd404d"
+source = "git+https://github.com/LiveSplit/livesplit-core#cbbee142db79a48fcb35b901739bc675e7574f12"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1184,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#dd0a22967a4755c5a52d12a5499dfefd86dd404d"
+source = "git+https://github.com/LiveSplit/livesplit-core#cbbee142db79a48fcb35b901739bc675e7574f12"
 dependencies = [
  "unicase",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,6 +839,8 @@ unsafe extern "C" fn settings_list_modified(
             obs_property_set_description(tooltip_property, DEFAULT_AUTO_SPLITTER_SETTING_TOOLTIP);
             obs_property_set_enabled(enable_property, false);
             obs_property_set_enabled(file_select_property, false);
+            obs_property_set_visible(enable_property, false);
+            obs_property_set_visible(file_select_property, false);
             return true;
         };
     }
@@ -861,6 +863,8 @@ unsafe extern "C" fn settings_list_modified(
             WidgetKind::Title { heading_level: _ } => {
                 obs_property_set_enabled(enable_property, false);
                 obs_property_set_enabled(file_select_property, false);
+                obs_property_set_visible(enable_property, false);
+                obs_property_set_visible(file_select_property, false);
             }
             WidgetKind::Bool {
                 default_value: default,
@@ -875,6 +879,8 @@ unsafe extern "C" fn settings_list_modified(
                     Some(Value::Bool(value)) => {
                         obs_property_set_enabled(enable_property, true);
                         obs_property_set_enabled(file_select_property, false);
+                        obs_property_set_visible(enable_property, true);
+                        obs_property_set_visible(file_select_property, false);
                         obs_data_set_bool(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_ENABLE, *value);
                     }
                     Some(_) => {
@@ -883,6 +889,8 @@ unsafe extern "C" fn settings_list_modified(
                     None => {
                         obs_property_set_enabled(enable_property, true);
                         obs_property_set_enabled(file_select_property, false);
+                        obs_property_set_visible(enable_property, true);
+                        obs_property_set_visible(file_select_property, false);
                         obs_data_set_bool(
                             settings,
                             SETTINGS_AUTO_SPLITTER_SETTINGS_ENABLE,
@@ -905,6 +913,8 @@ unsafe extern "C" fn settings_list_modified(
                     Some(Value::String(value)) => {
                         obs_property_set_enabled(enable_property, false);
                         obs_property_set_enabled(file_select_property, true);
+                        obs_property_set_visible(enable_property, false);
+                        obs_property_set_visible(file_select_property, true);
                         let path_cs = wasi_path::to_native(value).filter(|p| p.exists()).and_then(|p| {
                             CString::new(p.as_os_str().as_encoded_bytes()).ok()
                         }).unwrap_or_default();
@@ -916,6 +926,8 @@ unsafe extern "C" fn settings_list_modified(
                     None => {
                         obs_property_set_enabled(enable_property, false);
                         obs_property_set_enabled(file_select_property, true);
+                        obs_property_set_visible(enable_property, false);
+                        obs_property_set_visible(file_select_property, true);
                         obs_data_set_string(
                             settings,
                             SETTINGS_AUTO_SPLITTER_SETTINGS_FILE_SELECT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,10 +883,7 @@ unsafe extern "C" fn settings_list_modified(
                         obs_property_set_visible(file_select_property, false);
                         obs_data_set_bool(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_ENABLE, *value);
                     }
-                    Some(_) => {
-                        warn!("Unknown / unimplemented value type");
-                    }
-                    None => {
+                    _ => {
                         obs_property_set_enabled(enable_property, true);
                         obs_property_set_enabled(file_select_property, false);
                         obs_property_set_visible(enable_property, true);
@@ -920,10 +917,7 @@ unsafe extern "C" fn settings_list_modified(
                         }).unwrap_or_default();
                         obs_data_set_string(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_FILE_SELECT, path_cs.as_ptr());
                     }
-                    Some(_) => {
-                        warn!("Unknown / unimplemented value type");
-                    }
-                    None => {
+                    _ => {
                         obs_property_set_enabled(enable_property, false);
                         obs_property_set_enabled(file_select_property, true);
                         obs_property_set_visible(enable_property, false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,8 +975,6 @@ unsafe extern "C" fn settings_enable_modified(
 
     let value = obs_data_get_bool(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_ENABLE);
 
-    obs_data_set_bool(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_ENABLE, value);
-
     let setting_key = match list_setting_string.to_str() {
         Ok(value) => value,
         Err(_) => {
@@ -1019,8 +1017,6 @@ unsafe extern "C" fn settings_file_select_modified(
     let state: &mut State = &mut *data.cast();
 
     let value = obs_data_get_string(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_FILE_SELECT);
-
-    obs_data_set_string(settings, SETTINGS_AUTO_SPLITTER_SETTINGS_FILE_SELECT, value);
 
     let setting_key = match list_setting_string.to_str() {
         Ok(value) => value,


### PR DESCRIPTION
A companion PR to https://github.com/LiveSplit/livesplit-core/pull/748, depends on https://github.com/LiveSplit/obs-livesplit-one/pull/46.

Implements the FileSelect widget as a path in the OBS properties. The user can select a file, and the WASI-compatible path to that file gets stored in the settings map.

 - [x] Test it with an autosplitter that wouldn't split if it doesn't get the path properly, but does split if it works.