### PR TITLE
Add Choice Widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,7 +1165,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#591e760303a4931f15b68a62cb593a9280d048ed"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1181,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#591e760303a4931f15b68a62cb593a9280d048ed"
 dependencies = [
  "base64-simd",
  "bytemuck",
@@ -1217,14 +1223,14 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.7.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#591e760303a4931f15b68a62cb593a9280d048ed"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
  "crossbeam-channel",
  "evdev",
  "mio",
- "nix 0.27.1",
+ "nix 0.28.0",
  "promising-future",
  "serde",
  "windows-sys 0.52.0",
@@ -1234,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#591e760303a4931f15b68a62cb593a9280d048ed"
 dependencies = [
  "unicase",
 ]
@@ -1362,12 +1368,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -135,6 +135,8 @@ extern "C" {
         private: *mut c_void,
     );
     #[cfg(feature = "auto-splitting")]
+    pub fn obs_property_name(prop: *mut obs_property_t) -> *const c_char;
+    #[cfg(feature = "auto-splitting")]
     pub fn obs_property_set_description(prop: *mut obs_property_t, description: *const c_char);
     #[cfg(feature = "auto-splitting")]
     pub fn obs_property_set_enabled(prop: *mut obs_property_t, enabled: bool);


### PR DESCRIPTION
Implementation of a Choice widget.

Tasks:
- [x] Allow options from different choices to share the same key without bad collision effects.
- [x] Only show / enable the options relevant for the current "setting to be modified", hide / disable options from other choice settings.
  - NOTE: Using `obs_property_list_item_disable` is not good enough. That disables an option, but does not hide it. The option is still visible greyed-out.
  - So this PR now shows and hides entire drop-downs, not items in a single drop-down.