### PR TITLE
Fully show the auto splitter settings

### DIFF
--- a/.github/workflows/before_deploy.sh
+++ b/.github/workflows/before_deploy.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -ex
 
 main() {

--- a/.github/workflows/build_shared.sh
+++ b/.github/workflows/build_shared.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -ex
 
 main() {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -73,9 +73,9 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
@@ -91,9 +91,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -108,9 +108,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -152,7 +152,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -174,9 +174,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -230,9 +230,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cap-fs-ext"
@@ -319,6 +319,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clang-sys"
@@ -600,15 +606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -759,6 +757,7 @@ checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -816,9 +815,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
 dependencies = [
  "bytes",
  "fnv",
@@ -866,9 +865,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -877,12 +876,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -893,47 +904,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
+ "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -989,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6107a25f04af48ceeb4093eebc9b405ee5a1813a0bab5ecf1805d3eabb3337"
+checksum = "7a84a25dcae3ac487bc24ef280f9e20c79c9b1a3e5e32cbed3041d1c514aa87c"
 dependencies = [
  "byteorder",
  "thiserror",
@@ -999,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1145,7 +1169,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall",
 ]
@@ -1159,7 +1183,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#a13ea1b3b0f15fb8e4474a755cbb5fbb6cdb1ecc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1181,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#a13ea1b3b0f15fb8e4474a755cbb5fbb6cdb1ecc"
 dependencies = [
  "base64-simd",
  "bytemuck",
@@ -1217,14 +1241,14 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.7.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#a13ea1b3b0f15fb8e4474a755cbb5fbb6cdb1ecc"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "crossbeam-channel",
  "evdev",
  "mio",
- "nix 0.27.1",
+ "nix 0.28.0",
  "promising-future",
  "serde",
  "windows-sys 0.52.0",
@@ -1234,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#ef37e67adecc46ffe003851f0e97b8a3b1da7842"
+source = "git+https://github.com/LiveSplit/livesplit-core#a13ea1b3b0f15fb8e4474a755cbb5fbb6cdb1ecc"
 dependencies = [
  "unicase",
 ]
@@ -1321,6 +1345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,12 +1396,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1447,6 +1482,7 @@ dependencies = [
  "anyhow",
  "livesplit-core",
  "log",
+ "mime_guess",
  "obs",
  "open",
  "percent-encoding",
@@ -1504,6 +1540,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1716,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1745,20 +1801,22 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.26"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
+checksum = "e333b1eb9fe677f6893a9efcb0d277a2d3edd83f358a236b657c32301dc6e5f6"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -1768,7 +1826,8 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1813,11 +1872,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "itoa",
  "libc",
@@ -1828,24 +1887,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
 dependencies = [
  "log",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -1860,12 +1922,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pemfile"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1899,16 +1978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2061,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
@@ -2121,10 +2190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
-name = "syn"
-version = "2.0.52"
+name = "subtle"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "2.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2188,7 +2263,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0682e006dd35771e392a6623ac180999a9a854b1d4a6c12fb2e804941c2b1f58"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -2322,6 +2397,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.48.0",
@@ -2329,11 +2405,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2350,6 +2427,28 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2553,7 +2652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec11da24eed0ca98c3e071cf9186051b51b6436db21a7613498a9191d6f35a"
 dependencies = [
  "anyhow",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cap-rand",
  "cap-std",
  "io-extras",
@@ -2896,7 +2995,7 @@ checksum = "a5530d063ee9ccb1d503fed91e3d509419f43733a05fcc99c9f7aa3482703189"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -3119,7 +3218,7 @@ version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3174,6 +3273,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "obs-livesplit-one"
 version = "0.1.0"
 authors = ["Christopher Serr <christopher.serr@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.77"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,7 +18,7 @@ livesplit-core = { git = "https://github.com/LiveSplit/livesplit-core", features
     "software-rendering",
     "font-loading",
 ] }
-log = { version = "0.4.6", features = ["serde"] }
+log = { version = "0.4.6", features = ["serde", "release_max_level_info"] }
 serde = "1.0.188"
 serde_derive = "1.0.188"
 serde_json = "1.0.105"
@@ -30,10 +31,13 @@ quick-xml = { version = "0.31.0", features = [
     "serialize",
     "overlapped-lists",
 ], optional = true }
-reqwest = { version = "0.11.18", features = [
+reqwest = { version = "0.12.1", features = [
     "blocking",
+    "http2",
+    "macos-system-configuration",
     "rustls-tls-native-roots",
 ], default-features = false, optional = true }
+mime_guess = "2.0.4"
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 obs = { path = "obs" }

--- a/obs/src/lib.rs
+++ b/obs/src/lib.rs
@@ -102,6 +102,31 @@ pub extern "C" fn obs_data_get_bool(_data: *mut obs_data_t, _name: *const c_char
 }
 
 #[no_mangle]
+pub extern "C" fn obs_data_set_default_string(
+    _data: *mut obs_data_t,
+    _name: *const c_char,
+    _val: *const c_char,
+) {
+    panic!()
+}
+
+#[no_mangle]
+pub extern "C" fn obs_data_erase(_data: *mut obs_data_t, _name: *const c_char) {
+    panic!()
+}
+
+#[no_mangle]
+pub extern "C" fn obs_properties_add_group(
+    _props: *mut obs_properties_t,
+    _name: *const c_char,
+    _description: *const c_char,
+    _ty: obs_group_type,
+    _group: *mut obs_properties_t,
+) -> *mut obs_property_t {
+    panic!()
+}
+
+#[no_mangle]
 pub extern "C" fn obs_properties_add_int(
     _props: *mut obs_properties_t,
     _name: *const c_char,
@@ -211,6 +236,7 @@ pub extern "C" fn obs_properties_add_text(
 ) -> *mut obs_property_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_property_set_modified_callback2(
     _prop: *mut obs_property_t,
@@ -219,6 +245,7 @@ pub extern "C" fn obs_property_set_modified_callback2(
 ) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_property_set_description(
     _prop: *mut obs_property_t,
@@ -226,14 +253,25 @@ pub extern "C" fn obs_property_set_description(
 ) {
     panic!()
 }
+
+#[no_mangle]
+pub extern "C" fn obs_property_set_long_description(
+    _prop: *mut obs_property_t,
+    _long_description: *const c_char,
+) {
+    panic!()
+}
+
 #[no_mangle]
 pub extern "C" fn obs_property_set_enabled(_prop: *mut obs_property_t, _enabled: bool) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_property_set_visible(_prop: *mut obs_property_t, _visible: bool) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_properties_get(
     _props: *mut obs_properties_t,
@@ -241,6 +279,7 @@ pub extern "C" fn obs_properties_get(
 ) -> *mut obs_property_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_module_get_config_path(
     _module: *mut obs_module_t,
@@ -248,6 +287,7 @@ pub extern "C" fn obs_module_get_config_path(
 ) -> *const c_char {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_properties_add_list(
     _props: *mut obs_properties_t,
@@ -258,6 +298,7 @@ pub extern "C" fn obs_properties_add_list(
 ) -> *mut obs_property_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_properties_add_editable_list(
     _props: *mut obs_properties_t,
@@ -269,6 +310,7 @@ pub extern "C" fn obs_properties_add_editable_list(
 ) -> *mut obs_property_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_property_list_add_string(
     _prop: *mut obs_property_t,
@@ -277,10 +319,12 @@ pub extern "C" fn obs_property_list_add_string(
 ) -> size_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_set_bool(_data: *mut obs_data_t, _name: *const c_char, _val: bool) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_set_string(
     _data: *mut obs_data_t,
@@ -289,27 +333,38 @@ pub extern "C" fn obs_data_set_string(
 ) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_get_array(_data: *mut obs_data_t, _name: *const c_char) -> *mut c_void {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_array_count(_array: *mut c_void) -> size_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_array_item(_array: *mut c_void, _idx: size_t) -> *mut obs_data_t {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_array_release(_array: *mut c_void) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_release(_data: *mut obs_data_t) {
     panic!()
 }
+
 #[no_mangle]
 pub extern "C" fn obs_data_get_json(_data: *mut obs_data_t) -> *const c_char {
+    panic!()
+}
+
+#[no_mangle]
+pub extern "C" fn obs_source_update_properties(_source: *mut obs_source_t) {
     panic!()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -68,6 +68,22 @@ extern "C" {
         description: *const c_char,
     ) -> *mut obs_property_t;
     pub fn obs_data_get_bool(data: *mut obs_data_t, name: *const c_char) -> bool;
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_data_set_default_string(
+        data: *mut obs_data_t,
+        name: *const c_char,
+        val: *const c_char,
+    );
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_data_erase(data: *mut obs_data_t, name: *const c_char);
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_properties_add_group(
+        props: *mut obs_properties_t,
+        name: *const c_char,
+        description: *const c_char,
+        ty: obs_group_type,
+        group: *mut obs_properties_t,
+    ) -> *mut obs_property_t;
     pub fn obs_properties_add_text(
         props: *mut obs_properties_t,
         name: *const c_char,
@@ -137,6 +153,11 @@ extern "C" {
     #[cfg(feature = "auto-splitting")]
     pub fn obs_property_set_description(prop: *mut obs_property_t, description: *const c_char);
     #[cfg(feature = "auto-splitting")]
+    pub fn obs_property_set_long_description(
+        prop: *mut obs_property_t,
+        long_description: *const c_char,
+    );
+    #[cfg(feature = "auto-splitting")]
     pub fn obs_property_set_enabled(prop: *mut obs_property_t, enabled: bool);
     pub fn obs_property_set_visible(prop: *mut obs_property_t, visible: bool);
     pub fn obs_properties_get(
@@ -159,4 +180,7 @@ extern "C" {
     pub fn obs_data_array_release(array: *mut c_void);
     pub fn obs_data_release(data: *mut obs_data_t);
     pub fn obs_data_get_json(data: *mut obs_data_t) -> *const c_char;
+
+    #[cfg(feature = "auto-splitting")]
+    pub fn obs_source_update_properties(source: *mut obs_source_t);
 }

--- a/src/ffi_types.rs
+++ b/src/ffi_types.rs
@@ -63,6 +63,11 @@ pub const OBS_EDITABLE_LIST_TYPE_STRINGS: obs_editable_list_type = 0;
 pub const OBS_EDITABLE_LIST_TYPE_FILES: obs_editable_list_type = 1;
 pub const OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS: obs_editable_list_type = 2;
 
+pub type obs_group_type = u32;
+pub const OBS_COMBO_INVALID: obs_group_type = 0;
+pub const OBS_GROUP_NORMAL: obs_group_type = 1;
+pub const OBS_GROUP_CHECKABLE: obs_group_type = 2;
+
 pub type obs_data_t = obs_data;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
I randomly came across the `obs_source_update_properties` function in the documentation which allows us to dynamically rebuild the settings GUI whenever necessary. This allows us to properly show all the auto splitter settings and update them automatically when necessary.

Unfortunately the function is a little buggy in OBS and can cause internal race conditions that crash OBS. It's probably rather rare that this happens, so we can probably move forward with this implementation regardless for now. There is as far as I can tell no way to work around these issues.

The issue is tracked here:
https://github.com/obsproject/obs-studio/issues/10423