### PR TITLE
Add setting to control the timer timing method

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -90,7 +90,6 @@ unsafe extern "C" {
         description: *const c_char,
         text_type: obs_text_type,
     ) -> *mut obs_property_t;
-    #[cfg(feature = "auto-splitting")]
     pub fn obs_properties_add_list(
         props: *mut obs_properties_t,
         name: *const c_char,
@@ -106,7 +105,6 @@ unsafe extern "C" {
         filter: *const c_char,
         default_path: *const c_char,
     ) -> *mut obs_property_t;
-    #[cfg(feature = "auto-splitting")]
     pub fn obs_property_list_add_string(
         prop: *mut obs_property_t,
         name: *const c_char,


### PR DESCRIPTION
This PR adds a new combo box under the layout path to select the timing method (defaulting to real-time). The timing method gets applied every time a new `Run` is created, so it applies when first launching obs and when choosing a new split file. Additionally, if the setting changes this is applied to the timer.

The existing hotkey for toggling the timing method still exists but is not persistent. So the hotkey can be used to view the real-time (or game time) splits temporarily but the value of the setting remains unchanged.

I'm very happy about this PR because I have been switching to game time using the hotkey every time I load obs or a new split file, and this much more convenient.

Closes #59.