### PR TITLE
Add TheRun.gg Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "time",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -105,9 +105,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
@@ -258,7 +258,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "smallvec",
 ]
 
@@ -274,7 +274,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
@@ -299,7 +299,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winx",
 ]
 
@@ -471,36 +471,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cc4ac031157d0206cf6a8faa48284034721cd367a45e004c4e06329f51e106"
+checksum = "ba33ddc4e157cb1abe9da6c821e8824f99e56d057c2c22536850e0141f281d61"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a121c08faeeca04c85280dbddb19521e3ed7169430fd6abc34496e656c18b20"
+checksum = "69b23dd6ea360e6fb28a3f3b40b7f126509668f58076a4729b2cfd656f26a0ad"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f2b2cd8224147b4e193c2de68cf0085b693b242bb766c594828db3907151cb"
+checksum = "a9d81afcee8fe27ee2536987df3fadcb2e161af4edb7dbe3ef36838d0ce74382"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7468865d7cf72637a30d5fb97c4fc38b6ea82ab54ca913c81e7403274802be"
+checksum = "fb33595f1279fe7af03b28245060e9085caf98b10ed3137461a85796eb83972a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96c94a373ec1a35fb889730525f3fd220e66b1cf222b3426f5eb6e0404718e5"
+checksum = "0230a6ac0660bfe31eb244cbb43dcd4f2b3c1c4e0addc3e0348c6053ea60272e"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5904cbc4e8d4f8a69129a365da30d6f9f0e6ca024c4e0728d5da615e8db3c44"
+checksum = "96d6817fdc15cb8f236fc9d8e610767d3a03327ceca4abff7a14d8e2154c405e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -548,24 +548,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1009f9e206d5fba4add039539f3e16378815a53b8477bd2d1fc8e3bde6ea93a"
+checksum = "0403796328e9e2e7df2b80191cdbb473fd9ea3889eb45ef5632d0fef168ea032"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c5e3cc40402febecdba0a9e45999b1ab9aef8b120833182b08830b7be292fb"
+checksum = "188f04092279a3814e0b6235c2f9c2e34028e4beb72da7bfed55cbd184702bcc"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58a1de9bdab836734c42902ce948a5cdcc923ae8ce30b29a24dbe76098df659"
+checksum = "43f5e7391167605d505fe66a337e1a69583b3f34b63d359ffa5a430313c555e8"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3423b326097e627a378c106eb57d5ddb3f303d4deb87d29bf8b982dd1d6afc"
+checksum = "ea5440792eb2b5ba0a0976df371b9f94031bd853ae56f389de610bca7128a7cb"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -586,15 +586,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56f0e7abec391b94314ab2e9a1002c5a0aed6e29e4709318a7e33315767bed7"
+checksum = "1e5c05fab6fce38d729088f3fa1060eaa1ad54eefd473588887205ed2ab2f79e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e528d9c791306c55c3bef6c70a77cc9712ca9a32b12bae86924224e65604cb69"
+checksum = "9c9a0607a028edf5ba5bba7e7cf5ca1b7f0a030e3ae84dcd401e8b9b05192280"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.5"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8558dda6bd86b48c7b31b46555b5eed24b55c839e554a42765c23bf98de62997"
+checksum = "cb0f2da72eb2472aaac6cfba4e785af42b1f2d82f5155f30c9c30e8cce351e17"
 
 [[package]]
 name = "crc32fast"
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -790,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -875,7 +875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1380,9 +1380,9 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1471,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1532,9 +1532,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1545,7 +1545,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#de463fda4275370b2d774e6cf97bb2179e94496a"
+source = "git+https://github.com/LiveSplit/livesplit-core#c4a2068b71586d92d3864de00249226c88edf774"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#de463fda4275370b2d774e6cf97bb2179e94496a"
+source = "git+https://github.com/LiveSplit/livesplit-core#c4a2068b71586d92d3864de00249226c88edf774"
 dependencies = [
  "arc-swap",
  "base64-simd",
@@ -1588,6 +1588,7 @@ dependencies = [
  "livesplit-title-abbreviations",
  "log",
  "memchr",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1605,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.8.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#de463fda4275370b2d774e6cf97bb2179e94496a"
+source = "git+https://github.com/LiveSplit/livesplit-core#c4a2068b71586d92d3864de00249226c88edf774"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1622,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#de463fda4275370b2d774e6cf97bb2179e94496a"
+source = "git+https://github.com/LiveSplit/livesplit-core#c4a2068b71586d92d3864de00249226c88edf774"
 
 [[package]]
 name = "log"
@@ -1675,7 +1676,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -1869,6 +1870,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "shlex",
+ "time",
 ]
 
 [[package]]
@@ -1914,9 +1916,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2012,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a1abe1fcec21c32b62000af24b8b6db11b87609b64fd1c9a9e17c42422225"
+checksum = "499d922aa0f9faac8d92351416664f1b7acd914008a90fce2f0516d31efddf67"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2024,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d56dac306fbee0e990d4bac359c86d58f60f058e1e2d1aee1b7928689f08d3"
+checksum = "a3848fb193d6dffca43a21f24ca9492f22aab88af1223d06bac7f8a0ef405b81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2035,12 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-error"
@@ -2050,9 +2049,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.1"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd58c6a1fc307e1092aa0bb23d204ca4d1f021764142cd0424dccc84d2d5d106"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
  "serde",
@@ -2116,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2281,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2311,6 +2310,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2370,14 +2371,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2388,14 +2389,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2509,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -2522,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2729,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2827,9 +2828,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "termcolor"
@@ -2910,12 +2911,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2923,6 +2926,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-skia"
@@ -2977,9 +2990,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -3138,9 +3151,9 @@ checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3244,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3257,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3271,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3281,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3294,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3337,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901adbcfe03e3ad9db86f5665d6e00d54c904d4b81235c375635991596dfef3b"
+checksum = "6a2f8736ddc86e03a9d0e4c477a37939cfc53cd1b052ee38a3133679b87ef830"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3361,7 +3374,7 @@ dependencies = [
  "postcard",
  "pulley-interpreter",
  "rayon",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
@@ -3386,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00984333e84fa259b72b5bc113e1699d04f20c3ac191bf3e268e32bd93e493fd"
+checksum = "733682a327755c77153ac7455b1ba8f2db4d9946c1738f8002fe1fbda1d52e83"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -3413,18 +3426,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f42078a2603132bb5d7f2d5114ce57992e0fa344a9521385dc159c63472a9a"
+checksum = "68288980a2e02bcb368d436da32565897033ea21918007e3f2bae18843326cf9"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c271bbe00cf374564ee37bee4fe298f8ad10e267aba07b2ec598d376677f062"
+checksum = "5dea846da68f8e776c8a43bde3386022d7bb74e713b9654f7c0196e5ff2e4684"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -3437,15 +3450,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61fa3310d28256440f4bad63bd9462f364ee9faca7c3dcfccc7c2a48db46005"
+checksum = "fe1e5735b3c8251510d2a55311562772d6c6fca9438a3d0329eb6e38af4957d6"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6401e096bfbb50e75a00bd83162fee68b1800d65937364463a4ad43da3f140f8"
+checksum = "e89bb9ef571288e2be6b8a3c4763acc56c348dcd517500b1679d3ffad9e4a757"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3470,15 +3483,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd592465c4fffd866fc6f50db2cc7ae0c73d2742699e351b3680b5f84f21ede"
+checksum = "b698d004b15ea1f1ae2d06e5e8b80080cbd684fd245220ce2fac3cdd5ecf87f2"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.60.2",
@@ -3486,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6c60a180c90eea53266a6627c353a8101090f1e084f59e1bd4666f5c55e405"
+checksum = "c803a9fec05c3d7fa03474d4595079d546e77a3c71c1d09b21f74152e2165c17"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -3496,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe8de0903b246b59b112f2a7116f3d2315c41a9252ab78de90dae93b9cab50e"
+checksum = "d3866909d37f7929d902e6011847748147e8734e9d7e0353e78fb8b98f586aee"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3508,24 +3521,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d143a7388e4adfae7c1d6c6ceb44325b4b45b2e393e39b25ddaf563e7e587"
+checksum = "5a23b03fb14c64bd0dfcaa4653101f94ade76c34a3027ed2d6b373267536e45b"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de954a96e144df5b22805367f91a1754237f6bf99918f087d0ea1970be3b6365"
+checksum = "fbff220b88cdb990d34a20b13344e5da2e7b99959a5b1666106bec94b58d6364"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9923ac3d2b967e8ecbfefddaf19909b6a9a03b5b969b2a71af52300e3e404419"
+checksum = "13e1ad30e88988b20c0d1c56ea4b4fbc01a8c614653cbf12ca50c0dcc695e2f7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3536,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2c0062b75377b8d0a20239436b06df2e01a3521e9f14af6ea9b438c60fc030"
+checksum = "549aefdaa1398c2fcfbf69a7b882956bb5b6e8e5b600844ecb91a3b5bf658ca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3547,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8542e7cfd5b77ad33ac4cab866cb2b2eca350c7c34ac73e13fe78e83871ad3d7"
+checksum = "5cc96a84c5700171aeecf96fa9a9ab234f333f5afb295dabf3f8a812b70fe832"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3564,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c8be7f99d674c7af47ceba83ee4dc4e36132798c920a7bfd7ca44ce7733f99"
+checksum = "c28dc9efea511598c88564ac1974e0825c07d9c0de902dbf68f227431cd4ff8c"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3577,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001ee40c4a289579b0ef3c72cad1396a372dfb535b7b542ca4f7cb68d0566009"
+checksum = "c3c2e99fbaa0c26b4680e0c9af07e3f7b25f5fbc1ad97dd34067980bd027d3e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3594,7 +3607,7 @@ dependencies = [
  "futures",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "system-interface",
  "thiserror 2.0.18",
  "tokio",
@@ -3608,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69017e34b0285e3bce3add58b2895aded308400e5ad37ad4f670b0f9127d88f"
+checksum = "de2dc367052562c228ce51ee4426330840433c29c0ea3349eca5ddeb475ecdb9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3630,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3665,9 +3678,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wiggle"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d63a4f105596bfd9378d1f80659d01045f3ac803c4a1fab13ffe10e8d63227d"
+checksum = "c13d1ae265bd6e5e608827d2535665453cae5cb64950de66e2d5767d3e32c43a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3680,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c686a505d73cfd3508be4c92a51b7b3fac2268879c3bbb6bc98e37885fca8eb3"
+checksum = "607c4966f6b30da20d24560220137cbd09df722f0558eac81c05624700af5e05"
 dependencies = [
  "anyhow",
  "heck",
@@ -3694,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd3ac0e3ab2375cd9f439a4653fa714ca66798b1c8a3138db6ac752c600c77b"
+checksum = "fc36e39412fa35f7cc86b3705dbe154168721dd3e71f6dc4a726b266d5c60c55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3737,9 +3750,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.5"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce0c15cfd084585ed8f5519d4f405de98ff530f6afe31b88a5560688879c85e"
+checksum = "06c0ec09e8eb5e850e432da6271ed8c4a9d459a9db3850c38e98a3ee9d015e79"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
@@ -4254,18 +4267,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ auto-splitting = [
 ]
 therun-gg = [
     "livesplit-core/therun-gg",
+    "dep:open",
     "dep:reqwest",
     "dep:time",
     "tokio/rt-multi-thread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "obs-livesplit-one"
 version = "0.1.0"
 authors = ["Christopher Serr <christopher.serr@gmail.com>"]
-edition = "2021"
-rust-version = "1.87"
+edition = "2024"
+rust-version = "1.89"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -38,6 +38,9 @@ reqwest = { version = "0.13.2", features = [
     "rustls",
 ], default-features = false, optional = true }
 mime_guess = "2.0.4"
+time = { version = "0.3.47", features = [
+    "formatting",
+], default-features = false, optional = true }
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 obs = { path = "obs" }
@@ -46,7 +49,7 @@ obs = { path = "obs" }
 shlex = "1.1.0"
 
 [features]
-default = ["auto-splitting"]
+default = ["auto-splitting", "therun-gg"]
 auto-splitting = [
     "livesplit-core/auto-splitting",
     "dep:anyhow",
@@ -54,6 +57,11 @@ auto-splitting = [
     "dep:percent-encoding",
     "dep:quick-xml",
     "dep:reqwest",
+]
+therun-gg = [
+    "livesplit-core/therun-gg",
+    "dep:reqwest",
+    "dep:time",
 ]
 
 [profile.max-opt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ mime_guess = "2.0.4"
 time = { version = "0.3.47", features = [
     "formatting",
 ], default-features = false, optional = true }
+tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 obs = { path = "obs" }
@@ -62,6 +63,7 @@ therun-gg = [
     "livesplit-core/therun-gg",
     "dep:reqwest",
     "dep:time",
+    "tokio/rt-multi-thread",
 ]
 
 [profile.max-opt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ mime_guess = "2.0.4"
 time = { version = "0.3.47", features = [
     "formatting",
 ], default-features = false, optional = true }
+tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
 obs = { path = "obs" }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -68,7 +68,7 @@ unsafe extern "C" {
         description: *const c_char,
     ) -> *mut obs_property_t;
     pub fn obs_data_get_bool(data: *mut obs_data_t, name: *const c_char) -> bool;
-    #[cfg(feature = "auto-splitting")]
+    #[cfg(any(feature = "auto-splitting", feature = "therun-gg"))]
     pub fn obs_data_set_default_string(
         data: *mut obs_data_t,
         name: *const c_char,
@@ -76,7 +76,7 @@ unsafe extern "C" {
     );
     #[cfg(feature = "auto-splitting")]
     pub fn obs_data_erase(data: *mut obs_data_t, name: *const c_char);
-    #[cfg(feature = "auto-splitting")]
+    #[cfg(any(feature = "auto-splitting", feature = "therun-gg"))]
     pub fn obs_properties_add_group(
         props: *mut obs_properties_t,
         name: *const c_char,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use ffi::{
 use ffi_types::{
     obs_media_state, obs_module_t, obs_properties_t, LOG_DEBUG, LOG_ERROR, LOG_INFO,
     OBS_MEDIA_STATE_ENDED, OBS_MEDIA_STATE_PAUSED, OBS_MEDIA_STATE_PLAYING,
-    OBS_MEDIA_STATE_STOPPED, OBS_PATH_DIRECTORY, OBS_TEXT_DEFAULT,
+    OBS_MEDIA_STATE_STOPPED, OBS_PATH_DIRECTORY, OBS_TEXT_DEFAULT, OBS_TEXT_PASSWORD,
 };
 
 use livesplit_core::{
@@ -64,16 +64,20 @@ use crate::localization::{lang, Text};
 #[cfg(feature = "auto-splitting")]
 use {
     self::ffi::{
-        obs_data_erase, obs_data_set_default_string, obs_data_set_string, obs_properties_add_group,
-        obs_properties_add_list, obs_property_list_add_string, obs_property_set_description,
-        obs_property_set_enabled, obs_property_set_long_description, obs_source_update_properties,
-        OBS_COMBO_FORMAT_STRING, OBS_COMBO_TYPE_LIST, OBS_GROUP_NORMAL, OBS_TEXT_INFO,
+        obs_data_erase, obs_data_set_string, obs_properties_add_list, obs_property_list_add_string,
+        obs_property_set_description, obs_property_set_enabled, obs_property_set_long_description,
+        obs_source_update_properties, OBS_COMBO_FORMAT_STRING, OBS_COMBO_TYPE_LIST, OBS_TEXT_INFO,
     },
     livesplit_core::auto_splitting::{
         self,
         settings::{self, FileFilter, Value, Widget, WidgetKind},
         wasi_path,
     },
+};
+
+#[cfg(any(feature = "auto-splitting", feature = "therun-gg"))]
+use {
+    self::ffi::{obs_data_set_default_string, obs_properties_add_group, OBS_GROUP_NORMAL},
     std::ffi::CString,
 };
 
@@ -369,6 +373,12 @@ struct State {
     auto_splitter_map: settings::Map,
     #[cfg(feature = "auto-splitting")]
     source: *mut obs_source_t,
+    #[cfg(feature = "therun-gg")]
+    therun_api_key: String,
+    #[cfg(feature = "therun-gg")]
+    therun_live_tracking: bool,
+    #[cfg(feature = "therun-gg")]
+    therun_stats_uploading: bool,
 }
 
 impl Drop for State {
@@ -394,6 +404,12 @@ struct Settings {
     layout: Layout,
     width: u32,
     height: u32,
+    #[cfg(feature = "therun-gg")]
+    therun_api_key: String,
+    #[cfg(feature = "therun-gg")]
+    therun_live_tracking: bool,
+    #[cfg(feature = "therun-gg")]
+    therun_stats_uploading: bool,
 }
 
 #[derive(Deserialize)]
@@ -527,6 +543,16 @@ unsafe fn parse_settings(settings: *mut obs_data_t) -> Settings {
         let width = obs_data_get_int(settings, SETTINGS_WIDTH) as u32;
         let height = obs_data_get_int(settings, SETTINGS_HEIGHT) as u32;
 
+        #[cfg(feature = "therun-gg")]
+        let therun_api_key =
+            CStr::from_ptr(obs_data_get_string(settings, SETTINGS_THERUN_API_KEY).cast())
+                .to_string_lossy()
+                .to_string();
+        #[cfg(feature = "therun-gg")]
+        let therun_live_tracking = obs_data_get_bool(settings, SETTINGS_THERUN_LIVE_TRACKING);
+        #[cfg(feature = "therun-gg")]
+        let therun_stats_uploading = obs_data_get_bool(settings, SETTINGS_THERUN_STATS_UPLOADING);
+
         Settings {
             #[cfg(feature = "auto-splitting")]
             local_auto_splitter,
@@ -540,6 +566,12 @@ unsafe fn parse_settings(settings: *mut obs_data_t) -> Settings {
             layout,
             width,
             height,
+            #[cfg(feature = "therun-gg")]
+            therun_api_key,
+            #[cfg(feature = "therun-gg")]
+            therun_live_tracking,
+            #[cfg(feature = "therun-gg")]
+            therun_stats_uploading,
         }
     }
 }
@@ -559,6 +591,12 @@ impl State {
             layout,
             width,
             height,
+            #[cfg(feature = "therun-gg")]
+            therun_api_key,
+            #[cfg(feature = "therun-gg")]
+            therun_live_tracking,
+            #[cfg(feature = "therun-gg")]
+            therun_stats_uploading,
         }: Settings,
         _source: *mut obs_source_t,
         obs_settings: *mut obs_data_t,
@@ -571,6 +609,14 @@ impl State {
                 .timer
                 .auto_save
                 .store(auto_save, atomic::Ordering::Relaxed);
+
+            #[cfg(feature = "therun-gg")]
+            configure_therun_gg_client(
+                &global_timer,
+                &therun_api_key,
+                therun_live_tracking,
+                therun_stats_uploading,
+            );
 
             let state = LayoutState::default();
             let renderer = Renderer::new();
@@ -608,6 +654,12 @@ impl State {
                 auto_splitter_map: settings::Map::new(),
                 #[cfg(feature = "auto-splitting")]
                 source: _source,
+                #[cfg(feature = "therun-gg")]
+                therun_api_key,
+                #[cfg(feature = "therun-gg")]
+                therun_live_tracking,
+                #[cfg(feature = "therun-gg")]
+                therun_stats_uploading,
             }
         }
     }
@@ -1142,6 +1194,14 @@ unsafe extern "C" fn splits_path_modified(
 
         handle_splits_path_change(state, splits_path);
 
+        #[cfg(feature = "therun-gg")]
+        configure_therun_gg_client(
+            &state.global_timer,
+            &state.therun_api_key,
+            state.therun_live_tracking,
+            state.therun_stats_uploading,
+        );
+
         #[cfg(feature = "auto-splitting")]
         {
             let info_text = obs_properties_get(_props, SETTINGS_AUTO_SPLITTER_INFO);
@@ -1317,6 +1377,23 @@ unsafe extern "C" fn auto_splitter_open_website(
     }
 }
 
+#[cfg(feature = "therun-gg")]
+unsafe extern "C" fn therun_open_website(
+    _props: *mut obs_properties_t,
+    _prop: *mut obs_property_t,
+    _data: *mut c_void,
+) -> bool {
+    let url = "https://therun.gg/livesplit";
+    info!("Opening therun.gg website: {url}");
+    match open::that(url) {
+        Ok(_) => {}
+        Err(e) => {
+            error!("Could not open website {e}.")
+        }
+    }
+    false
+}
+
 unsafe extern "C" fn media_get_state(data: *mut c_void) -> obs_media_state {
     unsafe {
         let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
@@ -1424,6 +1501,12 @@ const SETTINGS_AUTO_SPLITTER_ACTIVATE: *const c_char = cstr!(c"auto_splitter_act
 const SETTINGS_AUTO_SPLITTER_WEBSITE: *const c_char = cstr!(c"auto_splitter_website");
 const SETTINGS_LAYOUT_PATH: *const c_char = cstr!(c"layout_path");
 const SETTINGS_SAVE_SPLITS: *const c_char = cstr!(c"save_splits");
+#[cfg(feature = "therun-gg")]
+const SETTINGS_THERUN_API_KEY: *const c_char = cstr!(c"therun_api_key");
+#[cfg(feature = "therun-gg")]
+const SETTINGS_THERUN_LIVE_TRACKING: *const c_char = cstr!(c"therun_live_tracking");
+#[cfg(feature = "therun-gg")]
+const SETTINGS_THERUN_STATS_UPLOADING: *const c_char = cstr!(c"therun_stats_uploading");
 
 unsafe extern "C" fn get_properties(data: *mut c_void) -> *mut obs_properties_t {
     unsafe {
@@ -1542,6 +1625,45 @@ unsafe extern "C" fn get_properties(data: *mut c_void) -> *mut obs_properties_t 
         );
 
         obs_property_set_modified_callback2(splits_path, Some(splits_path_modified), data);
+
+        #[cfg(feature = "therun-gg")]
+        {
+            let therun_gg_properties = obs_properties_create();
+
+            let _api_key = obs_properties_add_text(
+                therun_gg_properties,
+                SETTINGS_THERUN_API_KEY,
+                Text::TheRunApiKey.resolve(lang),
+                OBS_TEXT_PASSWORD,
+            );
+
+            let _get_api_key = obs_properties_add_button(
+                therun_gg_properties,
+                cstr!(c"therun_get_api_key"),
+                Text::TheRunGetApiKey.resolve(lang),
+                Some(therun_open_website),
+            );
+
+            let _live_tracking = obs_properties_add_bool(
+                therun_gg_properties,
+                SETTINGS_THERUN_LIVE_TRACKING,
+                Text::TheRunLiveTracking.resolve(lang),
+            );
+
+            let _stats_uploading = obs_properties_add_bool(
+                therun_gg_properties,
+                SETTINGS_THERUN_STATS_UPLOADING,
+                Text::TheRunStatsUploading.resolve(lang),
+            );
+
+            let _group = obs_properties_add_group(
+                props,
+                cstr!(c"therun_gg_settings_group"),
+                Text::TheRunSettingsGroup.resolve(lang),
+                OBS_GROUP_NORMAL,
+                therun_gg_properties,
+            );
+        }
 
         #[cfg(feature = "auto-splitting")]
         {
@@ -1815,6 +1937,13 @@ unsafe extern "C" fn get_defaults(settings: *mut obs_data_t) {
         obs_data_set_default_int(settings, SETTINGS_WIDTH, 300);
         obs_data_set_default_int(settings, SETTINGS_HEIGHT, 500);
         obs_data_set_default_bool(settings, SETTINGS_AUTO_SAVE, false);
+        #[cfg(feature = "therun-gg")]
+        {
+            let empty = CString::new("").unwrap();
+            obs_data_set_default_string(settings, SETTINGS_THERUN_API_KEY, empty.as_ptr());
+            obs_data_set_default_bool(settings, SETTINGS_THERUN_LIVE_TRACKING, true);
+            obs_data_set_default_bool(settings, SETTINGS_THERUN_STATS_UPLOADING, true);
+        }
     }
 }
 
@@ -1844,6 +1973,9 @@ unsafe extern "C" fn update(data: *mut c_void, settings_obj: *mut obs_data_t) {
 
         let settings = parse_settings(settings_obj);
 
+        #[cfg(feature = "therun-gg")]
+        let timer_path_changed = state.global_timer.timer.path != settings.splits_path;
+
         handle_splits_path_change(state, settings.splits_path);
 
         state.use_game_arguments = settings.use_game_arguments;
@@ -1860,6 +1992,25 @@ unsafe extern "C" fn update(data: *mut c_void, settings_obj: *mut obs_data_t) {
             .auto_save
             .store(settings.auto_save, atomic::Ordering::Relaxed);
         state.layout = settings.layout;
+
+        #[cfg(feature = "therun-gg")]
+        {
+            if timer_path_changed || state.therun_api_key != settings.therun_api_key {
+                configure_therun_gg_client(
+                    &state.global_timer,
+                    &settings.therun_api_key,
+                    settings.therun_live_tracking,
+                    settings.therun_stats_uploading,
+                );
+            } else {
+                let mut client = state.global_timer.timer.therun_gg_client.write().unwrap();
+                client.set_live_tracking_enabled(settings.therun_live_tracking);
+                client.set_stats_uploading_enabled(settings.therun_stats_uploading);
+            }
+            state.therun_api_key = settings.therun_api_key;
+            state.therun_live_tracking = settings.therun_live_tracking;
+            state.therun_stats_uploading = settings.therun_stats_uploading;
+        }
 
         #[cfg(feature = "auto-splitting")]
         {
@@ -1960,6 +2111,21 @@ unsafe extern "C" fn update(data: *mut c_void, settings_obj: *mut obs_data_t) {
 
 fn handle_splits_path_change(state: &mut State, splits_path: PathBuf) {
     state.global_timer = get_global_timer(splits_path);
+}
+
+#[cfg(feature = "therun-gg")]
+fn configure_therun_gg_client(
+    global_timer: &GlobalTimer,
+    api_key: &str,
+    live_tracking: bool,
+    stats_uploading: bool,
+) {
+    let mut client = global_timer.timer.therun_gg_client.write().unwrap();
+    if !api_key.is_empty() {
+        *client = therun_gg::Client::new(api_key.to_owned(), live_tracking, stats_uploading);
+    }
+    client.set_live_tracking_enabled(live_tracking);
+    client.set_stats_uploading_enabled(stats_uploading);
 }
 
 fn get_global_timer(splits_path: PathBuf) -> Arc<GlobalTimer> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     ptr,
     sync::{
         atomic::{self, AtomicBool, AtomicPtr},
-        Arc, Mutex, RwLock, RwLockReadGuard, Weak,
+        Arc, Mutex, OnceLock, RwLock, RwLockReadGuard, Weak,
     },
 };
 
@@ -77,6 +77,11 @@ use {
     std::ffi::CString,
 };
 
+#[cfg(feature = "therun-gg")]
+use livesplit_core::networking::therun_gg;
+#[cfg(feature = "therun-gg")]
+use tokio::runtime::{Builder, Runtime};
+
 macro_rules! cstr {
     ($f:literal) => {
         std::ffi::CStr::as_ptr($f)
@@ -119,6 +124,8 @@ struct InnerTimer {
     can_save_splits: bool,
     timer: RwLock<Timer>,
     auto_save: AtomicBool,
+    #[cfg(feature = "therun-gg")]
+    therun_gg_client: RwLock<therun_gg::Client>,
 }
 
 impl InnerTimer {
@@ -130,21 +137,47 @@ impl InnerTimer {
             }
         }
     }
+
+    #[cfg(feature = "therun-gg")]
+    fn send_to_therun_gg(&self, result: &Result) {
+        let Some(runtime) = TOKIO_RUNTIME.get() else {
+            error!("Tokio runtime not initialized");
+            return;
+        };
+
+        let timer = self.timer.read().unwrap();
+        let snapshot = timer.snapshot();
+        let mut client = self.therun_gg_client.write().unwrap();
+
+        if let Some(event) = result.as_ref().ok() {
+            if let Some(future) = client.handle_event(event.clone(), &snapshot) {
+                runtime.spawn(async move {
+                    future.await;
+                });
+            }
+        }
+    }
+
+    #[cfg(not(feature = "therun-gg"))]
+    fn send_to_therun_gg(&self, _result: &Result) {}
 }
 
 impl CommandSink for InnerTimer {
     fn start(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().start();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn split(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().split();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn split_or_start(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().split_or_start();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -159,36 +192,44 @@ impl CommandSink for InnerTimer {
             self.save();
         }
 
+        self.send_to_therun_gg(&result);
+
         async move { result }
     }
 
     fn undo_split(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().undo_split();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn skip_split(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().skip_split();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn toggle_pause_or_start(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().toggle_pause_or_start();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn pause(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().pause();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn resume(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().resume();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn undo_all_pauses(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().undo_all_pauses();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -209,16 +250,19 @@ impl CommandSink for InnerTimer {
 
     fn set_game_time(&self, time: TimeSpan) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().set_game_time(time);
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn pause_game_time(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().pause_game_time();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn resume_game_time(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().resume_game_time();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -240,6 +284,7 @@ impl CommandSink for InnerTimer {
             .write()
             .unwrap()
             .set_current_comparison(comparison);
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -256,11 +301,13 @@ impl CommandSink for InnerTimer {
 
     fn initialize_game_time(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().initialize_game_time();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn set_loading_times(&self, time: TimeSpan) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().set_loading_times(time);
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 }
@@ -274,6 +321,9 @@ impl TimerQuery for InnerTimer {
 }
 
 static TIMERS: Mutex<Vec<Weak<GlobalTimer>>> = Mutex::new(Vec::new());
+
+#[cfg(feature = "therun-gg")]
+static TOKIO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 struct State {
     #[cfg(feature = "auto-splitting")]
@@ -595,23 +645,38 @@ unsafe extern "C" fn get_name(_: *mut c_void) -> *const c_char {
     cstr!(c"LiveSplit One")
 }
 
+fn with_active_timer(data: *mut c_void) -> Option<Arc<InnerTimer>> {
+    unsafe {
+        let guard = (*data.cast::<Mutex<State>>()).lock().unwrap();
+        if !guard.activated {
+            return None;
+        }
+        let timer = guard.global_timer.timer.clone();
+        drop(guard);
+        Some(timer)
+    }
+}
+
+fn with_timer(data: *mut c_void) -> Arc<InnerTimer> {
+    unsafe {
+        let guard = (*data.cast::<Mutex<State>>()).lock().unwrap();
+        let timer = guard.global_timer.timer.clone();
+        drop(guard);
+        timer
+    }
+}
+
 unsafe extern "C" fn split(
     data: *mut c_void,
     _: obs_hotkey_id,
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.split_or_start());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.split_or_start());
     }
 }
 
@@ -621,17 +686,11 @@ unsafe extern "C" fn reset(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.reset(None));
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.reset(None));
     }
 }
 
@@ -641,17 +700,11 @@ unsafe extern "C" fn undo(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.undo_split());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.undo_split());
     }
 }
 
@@ -661,17 +714,11 @@ unsafe extern "C" fn skip(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.skip_split());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.skip_split());
     }
 }
 
@@ -681,17 +728,11 @@ unsafe extern "C" fn pause(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.toggle_pause_or_start());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.toggle_pause_or_start());
     }
 }
 
@@ -701,17 +742,11 @@ unsafe extern "C" fn undo_all_pauses(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.undo_all_pauses());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.undo_all_pauses());
     }
 }
 
@@ -721,17 +756,11 @@ unsafe extern "C" fn previous_comparison(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.switch_to_previous_comparison());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.switch_to_previous_comparison());
     }
 }
 
@@ -741,17 +770,11 @@ unsafe extern "C" fn next_comparison(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.switch_to_next_comparison());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.switch_to_next_comparison());
     }
 }
 
@@ -761,17 +784,11 @@ unsafe extern "C" fn toggle_timing_method(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.toggle_timing_method());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.toggle_timing_method());
     }
 }
 
@@ -1295,23 +1312,25 @@ unsafe extern "C" fn media_get_state(data: *mut c_void) -> obs_media_state {
 
 unsafe extern "C" fn media_play_pause(data: *mut c_void, pause: bool) {
     unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        let phase = state.global_timer.timer.get_timer().current_phase();
+        let guard = (*data.cast::<Mutex<State>>()).lock().unwrap();
+        let phase = guard.global_timer.timer.get_timer().current_phase();
+        let timer = guard.global_timer.timer.clone();
+        drop(guard);
         match phase {
             TimerPhase::NotRunning => {
                 if !pause {
-                    drop(state.global_timer.timer.start());
+                    drop(timer.start());
                 }
             }
             TimerPhase::Running => {
                 if pause {
-                    drop(state.global_timer.timer.pause());
+                    drop(timer.pause());
                 }
             }
             TimerPhase::Ended => {}
             TimerPhase::Paused => {
                 if !pause {
-                    drop(state.global_timer.timer.resume());
+                    drop(timer.resume());
                 }
             }
         }
@@ -1319,32 +1338,21 @@ unsafe extern "C" fn media_play_pause(data: *mut c_void, pause: bool) {
 }
 
 unsafe extern "C" fn media_restart(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.reset(None));
-        drop(state.global_timer.timer.start());
-    }
+    let timer = with_timer(data);
+    drop(timer.reset(None));
+    drop(timer.start());
 }
 
 unsafe extern "C" fn media_stop(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.reset(None));
-    }
+    drop(with_timer(data).reset(None));
 }
 
 unsafe extern "C" fn media_next(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.split());
-    }
+    drop(with_timer(data).split());
 }
 
 unsafe extern "C" fn media_previous(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.undo_split());
-    }
+    drop(with_timer(data).undo_split());
 }
 
 unsafe extern "C" fn media_get_time(data: *mut c_void) -> i64 {
@@ -1953,12 +1961,16 @@ fn get_global_timer(splits_path: PathBuf) -> Arc<GlobalTimer> {
         let timer = Timer::new(run).unwrap();
         #[cfg(feature = "auto-splitting")]
         let auto_splitter = auto_splitting::Runtime::new();
+        #[cfg(feature = "therun-gg")]
+        let therun_gg_client = therun_gg::Client::new(String::new(), false, false);
         let global_timer = Arc::new(GlobalTimer {
             timer: Arc::new(InnerTimer {
                 timer: RwLock::new(timer),
                 auto_save: AtomicBool::new(false),
                 path: splits_path,
                 can_save_splits,
+                #[cfg(feature = "therun-gg")]
+                therun_gg_client: RwLock::new(therun_gg_client),
             }),
             #[cfg(feature = "auto-splitting")]
             auto_splitter,
@@ -2054,6 +2066,20 @@ pub extern "C" fn obs_module_load() -> bool {
 
     unsafe {
         obs_register_source_s(source_info, mem::size_of_val(source_info) as _);
+    }
+
+    #[cfg(feature = "therun-gg")]
+    if TOKIO_RUNTIME
+        .set(
+            Builder::new_multi_thread()
+                .enable_all()
+                .worker_threads(1)
+                .build()
+                .expect("Failed to create tokio runtime"),
+        )
+        .is_err()
+    {
+        error!("Tokio runtime already initialized");
     }
 
     #[cfg(feature = "auto-splitting")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use ffi::{
 use ffi_types::{
     obs_media_state, obs_module_t, obs_properties_t, LOG_DEBUG, LOG_ERROR, LOG_INFO,
     OBS_MEDIA_STATE_ENDED, OBS_MEDIA_STATE_PAUSED, OBS_MEDIA_STATE_PLAYING,
-    OBS_MEDIA_STATE_STOPPED, OBS_PATH_DIRECTORY, OBS_TEXT_DEFAULT,
+    OBS_MEDIA_STATE_STOPPED, OBS_PATH_DIRECTORY, OBS_TEXT_DEFAULT, OBS_TEXT_PASSWORD,
 };
 
 use livesplit_core::{
@@ -349,6 +349,12 @@ struct State {
     auto_splitter_map: settings::Map,
     #[cfg(feature = "auto-splitting")]
     source: *mut obs_source_t,
+    #[cfg(feature = "therun-gg")]
+    therun_api_key: String,
+    #[cfg(feature = "therun-gg")]
+    therun_live_tracking: bool,
+    #[cfg(feature = "therun-gg")]
+    therun_stats_uploading: bool,
 }
 
 impl Drop for State {
@@ -374,6 +380,12 @@ struct Settings {
     layout: Layout,
     width: u32,
     height: u32,
+    #[cfg(feature = "therun-gg")]
+    therun_api_key: String,
+    #[cfg(feature = "therun-gg")]
+    therun_live_tracking: bool,
+    #[cfg(feature = "therun-gg")]
+    therun_stats_uploading: bool,
 }
 
 #[derive(Deserialize)]
@@ -507,6 +519,16 @@ unsafe fn parse_settings(settings: *mut obs_data_t) -> Settings {
         let width = obs_data_get_int(settings, SETTINGS_WIDTH) as u32;
         let height = obs_data_get_int(settings, SETTINGS_HEIGHT) as u32;
 
+        #[cfg(feature = "therun-gg")]
+        let therun_api_key =
+            CStr::from_ptr(obs_data_get_string(settings, SETTINGS_THERUN_API_KEY).cast())
+                .to_string_lossy()
+                .to_string();
+        #[cfg(feature = "therun-gg")]
+        let therun_live_tracking = obs_data_get_bool(settings, SETTINGS_THERUN_LIVE_TRACKING);
+        #[cfg(feature = "therun-gg")]
+        let therun_stats_uploading = obs_data_get_bool(settings, SETTINGS_THERUN_STATS_UPLOADING);
+
         Settings {
             #[cfg(feature = "auto-splitting")]
             local_auto_splitter,
@@ -520,6 +542,12 @@ unsafe fn parse_settings(settings: *mut obs_data_t) -> Settings {
             layout,
             width,
             height,
+            #[cfg(feature = "therun-gg")]
+            therun_api_key,
+            #[cfg(feature = "therun-gg")]
+            therun_live_tracking,
+            #[cfg(feature = "therun-gg")]
+            therun_stats_uploading,
         }
     }
 }
@@ -539,6 +567,12 @@ impl State {
             layout,
             width,
             height,
+            #[cfg(feature = "therun-gg")]
+            therun_api_key,
+            #[cfg(feature = "therun-gg")]
+            therun_live_tracking,
+            #[cfg(feature = "therun-gg")]
+            therun_stats_uploading,
         }: Settings,
         _source: *mut obs_source_t,
         obs_settings: *mut obs_data_t,
@@ -551,6 +585,20 @@ impl State {
                 .timer
                 .auto_save
                 .store(auto_save, atomic::Ordering::Relaxed);
+
+            #[cfg(feature = "therun-gg")]
+            {
+                let mut client = global_timer.timer.therun_gg_client.write().unwrap();
+                if !therun_api_key.is_empty() {
+                    *client = therun_gg::Client::new(
+                        therun_api_key.clone(),
+                        therun_live_tracking,
+                        therun_stats_uploading,
+                    );
+                }
+                client.set_live_tracking_enabled(therun_live_tracking);
+                client.set_stats_uploading_enabled(therun_stats_uploading);
+            }
 
             let state = LayoutState::default();
             let renderer = Renderer::new();
@@ -588,6 +636,12 @@ impl State {
                 auto_splitter_map: settings::Map::new(),
                 #[cfg(feature = "auto-splitting")]
                 source: _source,
+                #[cfg(feature = "therun-gg")]
+                therun_api_key,
+                #[cfg(feature = "therun-gg")]
+                therun_live_tracking,
+                #[cfg(feature = "therun-gg")]
+                therun_stats_uploading,
             }
         }
     }
@@ -1297,6 +1351,23 @@ unsafe extern "C" fn auto_splitter_open_website(
     }
 }
 
+#[cfg(feature = "therun-gg")]
+unsafe extern "C" fn therun_open_website(
+    _props: *mut obs_properties_t,
+    _prop: *mut obs_property_t,
+    _data: *mut c_void,
+) -> bool {
+    let url = "https://therun.gg/livesplit";
+    info!("Opening therun.gg website: {url}");
+    match open::that(url) {
+        Ok(_) => {}
+        Err(e) => {
+            error!("Could not open website {e}.")
+        }
+    }
+    false
+}
+
 unsafe extern "C" fn media_get_state(data: *mut c_void) -> obs_media_state {
     unsafe {
         let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
@@ -1404,6 +1475,12 @@ const SETTINGS_AUTO_SPLITTER_ACTIVATE: *const c_char = cstr!(c"auto_splitter_act
 const SETTINGS_AUTO_SPLITTER_WEBSITE: *const c_char = cstr!(c"auto_splitter_website");
 const SETTINGS_LAYOUT_PATH: *const c_char = cstr!(c"layout_path");
 const SETTINGS_SAVE_SPLITS: *const c_char = cstr!(c"save_splits");
+#[cfg(feature = "therun-gg")]
+const SETTINGS_THERUN_API_KEY: *const c_char = cstr!(c"therun_api_key");
+#[cfg(feature = "therun-gg")]
+const SETTINGS_THERUN_LIVE_TRACKING: *const c_char = cstr!(c"therun_live_tracking");
+#[cfg(feature = "therun-gg")]
+const SETTINGS_THERUN_STATS_UPLOADING: *const c_char = cstr!(c"therun_stats_uploading");
 
 unsafe extern "C" fn get_properties(data: *mut c_void) -> *mut obs_properties_t {
     unsafe {
@@ -1522,6 +1599,45 @@ unsafe extern "C" fn get_properties(data: *mut c_void) -> *mut obs_properties_t 
         );
 
         obs_property_set_modified_callback2(splits_path, Some(splits_path_modified), data);
+
+        #[cfg(feature = "therun-gg")]
+        {
+            let therun_gg_properties = obs_properties_create();
+
+            let _api_key = obs_properties_add_text(
+                therun_gg_properties,
+                SETTINGS_THERUN_API_KEY,
+                Text::TheRunApiKey.resolve(lang),
+                OBS_TEXT_PASSWORD,
+            );
+
+            let _get_api_key = obs_properties_add_button(
+                therun_gg_properties,
+                cstr!(c"therun_get_api_key"),
+                Text::TheRunGetApiKey.resolve(lang),
+                Some(therun_open_website),
+            );
+
+            let _live_tracking = obs_properties_add_bool(
+                therun_gg_properties,
+                SETTINGS_THERUN_LIVE_TRACKING,
+                Text::TheRunLiveTracking.resolve(lang),
+            );
+
+            let _stats_uploading = obs_properties_add_bool(
+                therun_gg_properties,
+                SETTINGS_THERUN_STATS_UPLOADING,
+                Text::TheRunStatsUploading.resolve(lang),
+            );
+
+            let _group = obs_properties_add_group(
+                props,
+                cstr!(c"therun_gg_settings_group"),
+                Text::TheRunSettingsGroup.resolve(lang),
+                OBS_GROUP_NORMAL,
+                therun_gg_properties,
+            );
+        }
 
         #[cfg(feature = "auto-splitting")]
         {
@@ -1795,6 +1911,13 @@ unsafe extern "C" fn get_defaults(settings: *mut obs_data_t) {
         obs_data_set_default_int(settings, SETTINGS_WIDTH, 300);
         obs_data_set_default_int(settings, SETTINGS_HEIGHT, 500);
         obs_data_set_default_bool(settings, SETTINGS_AUTO_SAVE, false);
+        #[cfg(feature = "therun-gg")]
+        {
+            let empty = CString::new("").unwrap();
+            obs_data_set_default_string(settings, SETTINGS_THERUN_API_KEY, empty.as_ptr());
+            obs_data_set_default_bool(settings, SETTINGS_THERUN_LIVE_TRACKING, true);
+            obs_data_set_default_bool(settings, SETTINGS_THERUN_STATS_UPLOADING, true);
+        }
     }
 }
 
@@ -1840,6 +1963,24 @@ unsafe extern "C" fn update(data: *mut c_void, settings_obj: *mut obs_data_t) {
             .auto_save
             .store(settings.auto_save, atomic::Ordering::Relaxed);
         state.layout = settings.layout;
+
+        #[cfg(feature = "therun-gg")]
+        {
+            if state.therun_api_key != settings.therun_api_key {
+                *state.global_timer.timer.therun_gg_client.write().unwrap() =
+                    therun_gg::Client::new(
+                        settings.therun_api_key.clone(),
+                        settings.therun_live_tracking,
+                        settings.therun_stats_uploading,
+                    );
+            }
+            let mut client = state.global_timer.timer.therun_gg_client.write().unwrap();
+            client.set_live_tracking_enabled(settings.therun_live_tracking);
+            client.set_stats_uploading_enabled(settings.therun_stats_uploading);
+            state.therun_api_key = settings.therun_api_key;
+            state.therun_live_tracking = settings.therun_live_tracking;
+            state.therun_stats_uploading = settings.therun_stats_uploading;
+        }
 
         #[cfg(feature = "auto-splitting")]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     ptr,
     sync::{
         atomic::{self, AtomicBool, AtomicPtr},
-        Arc, Mutex, RwLock, RwLockReadGuard, Weak,
+        Arc, Mutex, OnceLock, RwLock, RwLockReadGuard, Weak,
     },
 };
 
@@ -77,6 +77,11 @@ use {
     std::ffi::CString,
 };
 
+#[cfg(feature = "therun-gg")]
+use livesplit_core::networking::therun_gg;
+#[cfg(feature = "therun-gg")]
+use tokio::runtime::{Builder, Runtime};
+
 macro_rules! cstr {
     ($f:literal) => {
         std::ffi::CStr::as_ptr($f)
@@ -119,6 +124,8 @@ struct InnerTimer {
     can_save_splits: bool,
     timer: RwLock<Timer>,
     auto_save: AtomicBool,
+    #[cfg(feature = "therun-gg")]
+    therun_gg_client: RwLock<therun_gg::Client>,
 }
 
 impl InnerTimer {
@@ -130,21 +137,67 @@ impl InnerTimer {
             }
         }
     }
+
+    #[cfg(feature = "therun-gg")]
+    fn send_to_therun_gg(&self, result: &Result) {
+        let Some(runtime) = TOKIO_RUNTIME.get() else {
+            error!("Tokio runtime not initialized");
+            return;
+        };
+
+        let timer = self.timer.read().unwrap();
+        let snapshot = timer.snapshot();
+        let mut client = self.therun_gg_client.write().unwrap();
+
+        let Some(event) = result.as_ref().ok() else {
+            return;
+        };
+
+        if let Some(future) = client.handle_event(event.clone(), &snapshot) {
+            debug!("Sending {event:?} to therun.gg");
+            runtime.spawn(async move {
+                future.await;
+            });
+        } else if matches!(
+            event,
+            Event::Started
+                | Event::Splitted
+                | Event::Finished
+                | Event::Reset
+                | Event::SplitSkipped
+                | Event::SplitUndone
+                | Event::Paused
+                | Event::Resumed
+                | Event::PausesUndoneAndResumed
+                | Event::PausesUndone
+        ) && (snapshot.run().game_name().is_empty() || snapshot.run().category_name().is_empty())
+        {
+            warn!(
+                "No therun.gg update sent for {event:?}: the run has no game or category name"
+            );
+        }
+    }
+
+    #[cfg(not(feature = "therun-gg"))]
+    fn send_to_therun_gg(&self, _result: &Result) {}
 }
 
 impl CommandSink for InnerTimer {
     fn start(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().start();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn split(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().split();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn split_or_start(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().split_or_start();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -159,36 +212,44 @@ impl CommandSink for InnerTimer {
             self.save();
         }
 
+        self.send_to_therun_gg(&result);
+
         async move { result }
     }
 
     fn undo_split(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().undo_split();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn skip_split(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().skip_split();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn toggle_pause_or_start(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().toggle_pause_or_start();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn pause(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().pause();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn resume(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().resume();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn undo_all_pauses(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().undo_all_pauses();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -209,16 +270,19 @@ impl CommandSink for InnerTimer {
 
     fn set_game_time(&self, time: TimeSpan) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().set_game_time(time);
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn pause_game_time(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().pause_game_time();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn resume_game_time(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().resume_game_time();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -240,6 +304,7 @@ impl CommandSink for InnerTimer {
             .write()
             .unwrap()
             .set_current_comparison(comparison);
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
@@ -256,11 +321,13 @@ impl CommandSink for InnerTimer {
 
     fn initialize_game_time(&self) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().initialize_game_time();
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 
     fn set_loading_times(&self, time: TimeSpan) -> impl Future<Output = Result> + 'static {
         let result = self.timer.write().unwrap().set_loading_times(time);
+        self.send_to_therun_gg(&result);
         async move { result }
     }
 }
@@ -274,6 +341,9 @@ impl TimerQuery for InnerTimer {
 }
 
 static TIMERS: Mutex<Vec<Weak<GlobalTimer>>> = Mutex::new(Vec::new());
+
+#[cfg(feature = "therun-gg")]
+static TOKIO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 struct State {
     #[cfg(feature = "auto-splitting")]
@@ -595,23 +665,38 @@ unsafe extern "C" fn get_name(_: *mut c_void) -> *const c_char {
     cstr!(c"LiveSplit One")
 }
 
+fn with_active_timer(data: *mut c_void) -> Option<Arc<InnerTimer>> {
+    unsafe {
+        let guard = (*data.cast::<Mutex<State>>()).lock().unwrap();
+        if !guard.activated {
+            return None;
+        }
+        let timer = guard.global_timer.timer.clone();
+        drop(guard);
+        Some(timer)
+    }
+}
+
+fn with_timer(data: *mut c_void) -> Arc<InnerTimer> {
+    unsafe {
+        let guard = (*data.cast::<Mutex<State>>()).lock().unwrap();
+        let timer = guard.global_timer.timer.clone();
+        drop(guard);
+        timer
+    }
+}
+
 unsafe extern "C" fn split(
     data: *mut c_void,
     _: obs_hotkey_id,
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.split_or_start());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.split_or_start());
     }
 }
 
@@ -621,17 +706,11 @@ unsafe extern "C" fn reset(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.reset(None));
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.reset(None));
     }
 }
 
@@ -641,17 +720,11 @@ unsafe extern "C" fn undo(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.undo_split());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.undo_split());
     }
 }
 
@@ -661,17 +734,11 @@ unsafe extern "C" fn skip(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.skip_split());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.skip_split());
     }
 }
 
@@ -681,17 +748,11 @@ unsafe extern "C" fn pause(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.toggle_pause_or_start());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.toggle_pause_or_start());
     }
 }
 
@@ -701,17 +762,11 @@ unsafe extern "C" fn undo_all_pauses(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.undo_all_pauses());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.undo_all_pauses());
     }
 }
 
@@ -721,17 +776,11 @@ unsafe extern "C" fn previous_comparison(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.switch_to_previous_comparison());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.switch_to_previous_comparison());
     }
 }
 
@@ -741,17 +790,11 @@ unsafe extern "C" fn next_comparison(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.switch_to_next_comparison());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.switch_to_next_comparison());
     }
 }
 
@@ -761,17 +804,11 @@ unsafe extern "C" fn toggle_timing_method(
     _: *mut obs_hotkey_t,
     pressed: bool,
 ) {
-    unsafe {
-        if !pressed {
-            return;
-        }
-
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        if !state.activated {
-            return;
-        }
-
-        drop(state.global_timer.timer.toggle_timing_method());
+    if !pressed {
+        return;
+    }
+    if let Some(timer) = with_active_timer(data) {
+        drop(timer.toggle_timing_method());
     }
 }
 
@@ -1295,23 +1332,25 @@ unsafe extern "C" fn media_get_state(data: *mut c_void) -> obs_media_state {
 
 unsafe extern "C" fn media_play_pause(data: *mut c_void, pause: bool) {
     unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        let phase = state.global_timer.timer.get_timer().current_phase();
+        let guard = (*data.cast::<Mutex<State>>()).lock().unwrap();
+        let phase = guard.global_timer.timer.get_timer().current_phase();
+        let timer = guard.global_timer.timer.clone();
+        drop(guard);
         match phase {
             TimerPhase::NotRunning => {
                 if !pause {
-                    drop(state.global_timer.timer.start());
+                    drop(timer.start());
                 }
             }
             TimerPhase::Running => {
                 if pause {
-                    drop(state.global_timer.timer.pause());
+                    drop(timer.pause());
                 }
             }
             TimerPhase::Ended => {}
             TimerPhase::Paused => {
                 if !pause {
-                    drop(state.global_timer.timer.resume());
+                    drop(timer.resume());
                 }
             }
         }
@@ -1319,32 +1358,21 @@ unsafe extern "C" fn media_play_pause(data: *mut c_void, pause: bool) {
 }
 
 unsafe extern "C" fn media_restart(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.reset(None));
-        drop(state.global_timer.timer.start());
-    }
+    let timer = with_timer(data);
+    drop(timer.reset(None));
+    drop(timer.start());
 }
 
 unsafe extern "C" fn media_stop(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.reset(None));
-    }
+    drop(with_timer(data).reset(None));
 }
 
 unsafe extern "C" fn media_next(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.split());
-    }
+    drop(with_timer(data).split());
 }
 
 unsafe extern "C" fn media_previous(data: *mut c_void) {
-    unsafe {
-        let state: &mut State = &mut (*data.cast::<Mutex<State>>()).lock().unwrap();
-        drop(state.global_timer.timer.undo_split());
-    }
+    drop(with_timer(data).undo_split());
 }
 
 unsafe extern "C" fn media_get_time(data: *mut c_void) -> i64 {
@@ -1953,12 +1981,16 @@ fn get_global_timer(splits_path: PathBuf) -> Arc<GlobalTimer> {
         let timer = Timer::new(run).unwrap();
         #[cfg(feature = "auto-splitting")]
         let auto_splitter = auto_splitting::Runtime::new();
+        #[cfg(feature = "therun-gg")]
+        let therun_gg_client = therun_gg::Client::new(String::new(), false, false);
         let global_timer = Arc::new(GlobalTimer {
             timer: Arc::new(InnerTimer {
                 timer: RwLock::new(timer),
                 auto_save: AtomicBool::new(false),
                 path: splits_path,
                 can_save_splits,
+                #[cfg(feature = "therun-gg")]
+                therun_gg_client: RwLock::new(therun_gg_client),
             }),
             #[cfg(feature = "auto-splitting")]
             auto_splitter,
@@ -2054,6 +2086,20 @@ pub extern "C" fn obs_module_load() -> bool {
 
     unsafe {
         obs_register_source_s(source_info, mem::size_of_val(source_info) as _);
+    }
+
+    #[cfg(feature = "therun-gg")]
+    if TOKIO_RUNTIME
+        .set(
+            Builder::new_multi_thread()
+                .enable_all()
+                .worker_threads(1)
+                .build()
+                .expect("Failed to create tokio runtime"),
+        )
+        .is_err()
+    {
+        error!("Tokio runtime already initialized");
     }
 
     #[cfg(feature = "auto-splitting")]

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -60,6 +60,11 @@ pub enum Text {
     AutoSplitterSettingsGroup,
     AutoSplitterIncompatible,
     AutoSplitterUnavailable,
+    TheRunSettingsGroup,
+    TheRunApiKey,
+    TheRunLiveTracking,
+    TheRunStatsUploading,
+    TheRunGetApiKey,
 }
 
 impl Text {
@@ -122,6 +127,11 @@ fn resolve_english(text: Text) -> *const c_char {
             cstr!(c"This game's auto splitter is incompatible with LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"No auto splitter available for this game."),
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg Integration"),
+        Text::TheRunApiKey => cstr!(c"Upload Key"),
+        Text::TheRunLiveTracking => cstr!(c"Live Tracking"),
+        Text::TheRunStatsUploading => cstr!(c"Stats Uploading"),
+        Text::TheRunGetApiKey => cstr!(c"Get Upload Key"),
     }
 }
 
@@ -166,6 +176,11 @@ fn resolve_dutch(text: Text) -> *const c_char {
             cstr!(c"De auto-splitter van dit spel is niet compatibel met LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"Geen auto-splitter beschikbaar voor dit spel."),
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg-integratie"),
+        Text::TheRunApiKey => cstr!(c"Uploadsleutel"),
+        Text::TheRunLiveTracking => cstr!(c"Live tracking"),
+        Text::TheRunStatsUploading => cstr!(c"Statistieken uploaden"),
+        Text::TheRunGetApiKey => cstr!(c"Uploadsleutel ophalen"),
     }
 }
 
@@ -212,6 +227,11 @@ fn resolve_french(text: Text) -> *const c_char {
             cstr!(c"L'auto-splitter de ce jeu est incompatible avec LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"Aucun auto-splitter disponible pour ce jeu."),
+        Text::TheRunSettingsGroup => cstr!(c"Intégration TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Clé d'envoi"),
+        Text::TheRunLiveTracking => cstr!(c"Suivi en direct"),
+        Text::TheRunStatsUploading => cstr!(c"Envoi des statistiques"),
+        Text::TheRunGetApiKey => cstr!(c"Obtenir la clé d'envoi"),
     }
 }
 
@@ -256,6 +276,11 @@ fn resolve_german(text: Text) -> *const c_char {
         Text::AutoSplitterUnavailable => {
             cstr!(c"Für dieses Spiel ist kein Auto-Splitter verfügbar.")
         }
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg-Integration"),
+        Text::TheRunApiKey => cstr!(c"Upload-Schlüssel"),
+        Text::TheRunLiveTracking => cstr!(c"Live-Tracking"),
+        Text::TheRunStatsUploading => cstr!(c"Statistik-Upload"),
+        Text::TheRunGetApiKey => cstr!(c"Upload-Schlüssel holen"),
     }
 }
 
@@ -300,6 +325,11 @@ fn resolve_italian(text: Text) -> *const c_char {
         Text::AutoSplitterUnavailable => {
             cstr!(c"Nessun auto-splitter disponibile per questo gioco.")
         }
+        Text::TheRunSettingsGroup => cstr!(c"Integrazione TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Chiave di upload"),
+        Text::TheRunLiveTracking => cstr!(c"Tracciamento live"),
+        Text::TheRunStatsUploading => cstr!(c"Caricamento statistiche"),
+        Text::TheRunGetApiKey => cstr!(c"Ottieni chiave di upload"),
     }
 }
 
@@ -342,6 +372,11 @@ fn resolve_portuguese(text: Text) -> *const c_char {
             cstr!(c"O auto-splitter deste jogo é incompatível com o LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"Não há auto-splitter disponível para este jogo."),
+        Text::TheRunSettingsGroup => cstr!(c"Integração com TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Chave de upload"),
+        Text::TheRunLiveTracking => cstr!(c"Rastreamento ao vivo"),
+        Text::TheRunStatsUploading => cstr!(c"Envio de estatísticas"),
+        Text::TheRunGetApiKey => cstr!(c"Obter chave de upload"),
     }
 }
 
@@ -384,6 +419,11 @@ fn resolve_polish(text: Text) -> *const c_char {
             cstr!(c"Auto-splitter tej gry jest niezgodny z LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"Brak auto-splittera dla tej gry."),
+        Text::TheRunSettingsGroup => cstr!(c"Integracja z TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Klucz przesyłania"),
+        Text::TheRunLiveTracking => cstr!(c"Śledzenie na żywo"),
+        Text::TheRunStatsUploading => cstr!(c"Przesyłanie statystyk"),
+        Text::TheRunGetApiKey => cstr!(c"Pobierz klucz przesyłania"),
     }
 }
 
@@ -426,6 +466,11 @@ fn resolve_russian(text: Text) -> *const c_char {
             cstr!(c"Авто-сплиттер этой игры несовместим с LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"Для этой игры нет авто-сплиттера."),
+        Text::TheRunSettingsGroup => cstr!(c"Интеграция с TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Ключ загрузки"),
+        Text::TheRunLiveTracking => cstr!(c"Отслеживание в реальном времени"),
+        Text::TheRunStatsUploading => cstr!(c"Загрузка статистики"),
+        Text::TheRunGetApiKey => cstr!(c"Получить ключ загрузки"),
     }
 }
 
@@ -468,6 +513,11 @@ fn resolve_spanish(text: Text) -> *const c_char {
             cstr!(c"El auto-splitter de este juego es incompatible con LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"No hay auto-splitter disponible para este juego."),
+        Text::TheRunSettingsGroup => cstr!(c"Integración con TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Clave de subida"),
+        Text::TheRunLiveTracking => cstr!(c"Seguimiento en vivo"),
+        Text::TheRunStatsUploading => cstr!(c"Subida de estadísticas"),
+        Text::TheRunGetApiKey => cstr!(c"Obtener clave de subida"),
     }
 }
 
@@ -510,6 +560,11 @@ fn resolve_brazilian_portuguese(text: Text) -> *const c_char {
             cstr!(c"O auto-splitter deste jogo é incompatível com o LiveSplit One.")
         }
         Text::AutoSplitterUnavailable => cstr!(c"Nenhum auto-splitter disponível para este jogo."),
+        Text::TheRunSettingsGroup => cstr!(c"Integração com TheRun.gg"),
+        Text::TheRunApiKey => cstr!(c"Chave de upload"),
+        Text::TheRunLiveTracking => cstr!(c"Rastreamento ao vivo"),
+        Text::TheRunStatsUploading => cstr!(c"Envio de estatísticas"),
+        Text::TheRunGetApiKey => cstr!(c"Obter chave de upload"),
     }
 }
 
@@ -550,6 +605,11 @@ fn resolve_chinese_simplified(text: Text) -> *const c_char {
         Text::AutoSplitterSettingsGroup => cstr!(c"自动分段器设置"),
         Text::AutoSplitterIncompatible => cstr!(c"该游戏的自动分段器与 LiveSplit One 不兼容。"),
         Text::AutoSplitterUnavailable => cstr!(c"此游戏没有可用的自动分段器。"),
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg 集成"),
+        Text::TheRunApiKey => cstr!(c"上传密钥"),
+        Text::TheRunLiveTracking => cstr!(c"实时追踪"),
+        Text::TheRunStatsUploading => cstr!(c"统计上传"),
+        Text::TheRunGetApiKey => cstr!(c"获取上传密钥"),
     }
 }
 
@@ -590,6 +650,11 @@ fn resolve_chinese_traditional(text: Text) -> *const c_char {
         Text::AutoSplitterSettingsGroup => cstr!(c"自動分段器設定"),
         Text::AutoSplitterIncompatible => cstr!(c"此遊戲的自動分段器與 LiveSplit One 不相容。"),
         Text::AutoSplitterUnavailable => cstr!(c"此遊戲沒有可用的自動分段器。"),
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg 集成"),
+        Text::TheRunApiKey => cstr!(c"上傳密鑰"),
+        Text::TheRunLiveTracking => cstr!(c"即時追蹤"),
+        Text::TheRunStatsUploading => cstr!(c"統計上傳"),
+        Text::TheRunGetApiKey => cstr!(c"取得上傳密鑰"),
     }
 }
 
@@ -634,6 +699,11 @@ fn resolve_japanese(text: Text) -> *const c_char {
         Text::AutoSplitterUnavailable => {
             cstr!(c"このゲームで利用可能な自動スプリッターはありません。")
         }
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg 連携"),
+        Text::TheRunApiKey => cstr!(c"アップロードキー"),
+        Text::TheRunLiveTracking => cstr!(c"ライブ追跡"),
+        Text::TheRunStatsUploading => cstr!(c"統計のアップロード"),
+        Text::TheRunGetApiKey => cstr!(c"アップロードキーを取得"),
     }
 }
 
@@ -678,5 +748,10 @@ fn resolve_korean(text: Text) -> *const c_char {
         Text::AutoSplitterUnavailable => {
             cstr!(c"이 게임에 사용할 수 있는 자동 스플리터가 없습니다.")
         }
+        Text::TheRunSettingsGroup => cstr!(c"TheRun.gg 통합"),
+        Text::TheRunApiKey => cstr!(c"업로드 키"),
+        Text::TheRunLiveTracking => cstr!(c"실시간 추적"),
+        Text::TheRunStatsUploading => cstr!(c"통계 업로드"),
+        Text::TheRunGetApiKey => cstr!(c"업로드 키 가져오기"),
     }
 }


### PR DESCRIPTION
This pull request adds integration with TheRun.gg to the OBS plugin for LiveSplit One, following the changes in https://github.com/LiveSplit/livesplit-core/pull/903 and https://github.com/LiveSplit/LiveSplitOne/pull/1128.  Most of the work required in this PR making sure the TheRun.gg client and the tokio runtime it (via reqwest) requires are set up correctly, and managing the settings UI.  I've manually tested these changes with my own TheRun.gg key to make sure that splits are properly tracked.

This is how the settings UI looks now:

<img width="1752" height="2428" alt="Ekrankopio de 2026-04-02 02-52-13" src="https://github.com/user-attachments/assets/115fca22-cb8a-4f46-bb96-dab0a3f02d3b" />

I took the localizations from the LiveSplitOne web UI PR linked above, except for the `TheRunGetApiKey`/"Get Upload Key` string, which I used an LLM to translate into each supported language.  Spot checking the languages I'm familiar with, it looks reasonable.  I would appreciate native speaker input though.

Please see the commit messages for each patch in this pull request for more details.