### PR TITLE
Add AutoSplittingRuntime child support

### DIFF
--- a/src/auto_splitters.rs
+++ b/src/auto_splitters.rs
@@ -129,7 +129,21 @@ impl List {
     }
 
     pub fn get_website_for_game(&self, game_name: &str) -> Option<&str> {
-        self.get_for_game(game_name)?.website.as_deref()
+        let splitter = self.get_for_game(game_name)?;
+        splitter
+            .auto_splitting_runtime
+            .as_ref()
+            .and_then(|r| r.website.as_deref())
+            .or(splitter.website.as_deref())
+    }
+
+    pub fn get_description_for_game(&self, game_name: &str) -> Option<&str> {
+        let splitter = self.get_for_game(game_name)?;
+        splitter
+            .auto_splitting_runtime
+            .as_ref()
+            .and_then(|r| r.description.as_deref())
+            .or(Some(&splitter.description))
     }
 
     pub fn get_runtime_description_for_game(&self, game_name: &str) -> Option<&str> {

--- a/src/auto_splitters.rs
+++ b/src/auto_splitters.rs
@@ -88,6 +88,18 @@ pub struct AutoSplitter {
     pub description: String,
     #[serde(rename = "Website")]
     pub website: Option<String>,
+    #[serde(rename = "AutoSplittingRuntime")]
+    auto_splitting_runtime: Option<AutoSplittingRuntime>,
+}
+
+#[derive(Deserialize)]
+pub struct AutoSplittingRuntime {
+    #[serde(rename = "URL")]
+    pub url: String,
+    #[serde(rename = "Description")]
+    pub description: Option<String>,
+    #[serde(rename = "Website")]
+    pub website: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -118,6 +130,32 @@ impl List {
 
     pub fn get_website_for_game(&self, game_name: &str) -> Option<&str> {
         self.get_for_game(game_name)?.website.as_deref()
+    }
+
+    pub fn get_runtime_description_for_game(&self, game_name: &str) -> Option<&str> {
+        let splitter = self.get_for_game(game_name)?;
+        if splitter.auto_splitting_runtime.is_some() {
+            splitter
+                .auto_splitting_runtime
+                .as_ref()?
+                .description
+                .as_deref()
+        } else {
+            None
+        }
+    }
+
+    pub fn get_runtime_website_for_game(&self, game_name: &str) -> Option<&str> {
+        let splitter = self.get_for_game(game_name)?;
+        if splitter.auto_splitting_runtime.is_some() {
+            splitter
+                .auto_splitting_runtime
+                .as_ref()?
+                .website
+                .as_deref()
+        } else {
+            None
+        }
     }
 
     pub fn get_for_game(&self, game_name: &str) -> Option<&AutoSplitter> {
@@ -166,6 +204,34 @@ impl Downloader {
     }
 
     pub fn download(&self, auto_splitter: &AutoSplitter, folder: &Path) -> Option<PathBuf> {
+        // Prefer AutoSplittingRuntime child URL if present (new shape for PoE2).
+        // Old code ignored the unknown child and would not find the wasm.
+        if let Some(runtime) = &auto_splitter.auto_splitting_runtime {
+            let url = &runtime.url;
+            let is_wasm = Url::parse(url)
+                .ok()
+                .and_then(|u| {
+                    u.path_segments()
+                        .and_then(|mut s| s.next_back().map(|seg| seg.ends_with(".wasm")))
+                })
+                .unwrap_or_else(|| url.ends_with(".wasm"));
+            if is_wasm {
+                let mut file_paths = Vec::new();
+                if let Err(e) = self
+                    .download_file(url, folder, &mut file_paths)
+                    .with_context(|| format_err!("Failed downloading `{url}`."))
+                {
+                    error!("{e:#?}");
+                } else if let Some(wasm) = file_paths
+                    .into_iter()
+                    .find(|path| path.extension().is_some_and(|e| e == "wasm"))
+                {
+                    return Some(wasm);
+                }
+                // Fall through to legacy URLs if child download failed.
+            }
+        }
+
         let mut file_paths = Vec::new();
 
         for url in &auto_splitter.urls.urls {
@@ -213,9 +279,11 @@ impl Downloader {
 
 impl AutoSplitter {
     pub fn is_using_auto_splitting_runtime(&self) -> bool {
-        self.script_type
-            .as_ref()
-            .is_some_and(|t| t == "AutoSplittingRuntime")
+        self.auto_splitting_runtime.is_some()
+            || self
+                .script_type
+                .as_ref()
+                .is_some_and(|t| t == "AutoSplittingRuntime")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,7 +1133,10 @@ unsafe fn update_auto_splitter_ui(
 ) {
     unsafe {
         if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name) {
-            obs_property_set_enabled(website_button, auto_splitter.website.is_some());
+            obs_property_set_enabled(
+                website_button,
+                auto_splitters::get_list().get_website_for_game(game_name).is_some(),
+            );
 
             if !auto_splitter.is_using_auto_splitting_runtime() {
                 obs_property_set_enabled(activate_button, false);
@@ -1144,7 +1147,10 @@ unsafe fn update_auto_splitter_ui(
             } else {
                 obs_property_set_enabled(activate_button, true);
 
-                let mut auto_splitter_description = auto_splitter.description.as_bytes().to_vec();
+                let description = auto_splitters::get_list()
+                    .get_description_for_game(game_name)
+                    .unwrap_or("");
+                let mut auto_splitter_description = description.as_bytes().to_vec();
                 auto_splitter_description.push(0);
 
                 obs_property_set_description(


### PR DESCRIPTION
Adds support for the `<AutoSplittingRuntime>` child element from LiveSplit/LiveSplit.AutoSplitters#2878.

See that PR for context — this just teaches `src/auto_splitters.rs` to read the child.

Base: `master`.
